### PR TITLE
Add Mission Control web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,11 @@ python3 main_v2.py --preflight-only --steps publish_branch,draft_pr
 python3 main_v2.py --list-managed-agents
 python3 main_v2.py --doctor-config
 python3 main_v2.py --diagnose-plan --steps triage,implement
+python3 main_v2.py --web --web-host 127.0.0.1 --web-port 8766
 ```
+
+`--web` 会启动一个本地 Mission Control Web UI，用来集中做 pipeline 启动、diagnose / preflight / doctor、OpenClaw 健康检查、run artifacts 浏览，以及最近运行的清理。
+当前页面还带了一个 Readiness Gate，会结合请求内容、step 选择、repo git 状态、OpenClaw health / memory、fallback 解析和最近一次 preflight 结果，帮助你在真正 live 前先看风险。
 
 如果要临时改 agent 分配，不必改 pipeline step。本次运行前覆盖 assignment 即可，例如：
 

--- a/main_v2.py
+++ b/main_v2.py
@@ -52,6 +52,22 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Validate config references across profiles, managed_agents, assignments, and pipelines, then exit.",
     )
+    parser.add_argument(
+        "--web",
+        action="store_true",
+        help="Start the Mission Control Web UI.",
+    )
+    parser.add_argument(
+        "--web-host",
+        default="127.0.0.1",
+        help="Host to bind the Mission Control Web UI.",
+    )
+    parser.add_argument(
+        "--web-port",
+        type=int,
+        default=8765,
+        help="Port to bind the Mission Control Web UI.",
+    )
     return parser.parse_args()
 
 
@@ -406,6 +422,30 @@ async def main() -> None:
         ]
     )
 
+    if args.web:
+        if any(
+            [
+                args.request,
+                args.list_steps,
+                args.preflight_only,
+                args.list_managed_agents,
+                args.diagnose_plan,
+                args.doctor_config,
+            ]
+        ):
+            raise SystemExit(
+                "--web cannot be combined with --request or inspection-only flags."
+            )
+        from openclaw_v2.web import run_web_server
+
+        await run_web_server(
+            config_path=os.path.abspath(args.config),
+            repo_path=repo_path,
+            host=args.web_host,
+            port=args.web_port,
+        )
+        return
+
     if args.live and not (args.list_steps or args.preflight_only):
         _validate_live_policy(
             orchestrator,
@@ -460,4 +500,7 @@ async def main() -> None:
 
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    try:
+        asyncio.run(main())
+    except KeyboardInterrupt:
+        pass

--- a/openclaw_v2/orchestrator.py
+++ b/openclaw_v2/orchestrator.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import uuid
 from datetime import datetime, timezone
 from typing import Callable
 
@@ -32,7 +33,7 @@ class HybridOrchestrator:
     @staticmethod
     def _make_run_id() -> str:
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        return f"run-{timestamp}"
+        return f"run-{timestamp}-{uuid.uuid4().hex[:6]}"
 
     def build_plan(self, selected_steps: list[str] | None = None) -> list[WorkItem]:
         return self.planner.build_plan(selected_steps=selected_steps)

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -1,0 +1,1051 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import re
+import shutil
+import subprocess
+import uuid
+from dataclasses import asdict, dataclass, field, is_dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+from aiohttp import web
+
+from .config import diagnose_app_config, load_app_config, resolve_runtime_path
+from .models import TaskStatus
+from .orchestrator import HybridOrchestrator
+
+APP_CONFIG_PATH = web.AppKey("config_path", str)
+APP_REPO_PATH = web.AppKey("repo_path", str)
+APP_STATIC_ROOT = web.AppKey("static_root", str)
+APP_TASK_MANAGER = web.AppKey("task_manager", Any)
+
+
+def _json_ready(value: Any) -> Any:
+    if isinstance(value, Enum):
+        return value.value
+    if is_dataclass(value):
+        return _json_ready(asdict(value))
+    if isinstance(value, dict):
+        return {key: _json_ready(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_ready(item) for item in value]
+    return value
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_user_path(raw_path: str, base_path: str | None = None) -> str:
+    expanded = os.path.expanduser((raw_path or "").strip())
+    if not expanded:
+        return os.path.abspath(base_path or os.getcwd())
+    if os.path.isabs(expanded):
+        return os.path.abspath(expanded)
+    if base_path:
+        return os.path.abspath(os.path.join(base_path, expanded))
+    return os.path.abspath(expanded)
+
+
+def _selected_steps(payload: dict[str, Any]) -> list[str] | None:
+    raw_steps = payload.get("steps", [])
+    if isinstance(raw_steps, str):
+        values = [step.strip() for step in raw_steps.split(",") if step.strip()]
+        return values or None
+    if isinstance(raw_steps, list):
+        values = [str(step).strip() for step in raw_steps if str(step).strip()]
+        return values or None
+    return None
+
+
+def _default_openclaw_agent_id(config: Any) -> str:
+    env_value = os.getenv("OPENCLAW_AGENT_ID", "").strip()
+    if env_value:
+        return env_value
+    for profile in config.profiles.values():
+        if profile.mode.value == "openclaw" and profile.openclaw_agent_id.strip():
+            return profile.openclaw_agent_id.strip()
+    return "openclaw-control-ext"
+
+
+def _load_preflight_report(artifacts_dir: str) -> dict[str, Any] | None:
+    if not artifacts_dir:
+        return None
+    preflight_path = os.path.join(artifacts_dir, "metadata", "preflight.json")
+    if not os.path.exists(preflight_path):
+        return None
+    with open(preflight_path, "r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _summarize_recent_runs(artifacts_root: str, limit: int = 8) -> list[dict[str, Any]]:
+    runs: list[dict[str, Any]] = []
+    root = Path(artifacts_root)
+    if not root.exists():
+        return runs
+
+    candidates = sorted(
+        [path for path in root.iterdir() if path.is_dir() and path.name.startswith("run-")],
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+
+    for run_dir in candidates[:limit]:
+        summary_path = run_dir / "summary.json"
+        context_path = run_dir / "context.json"
+        if not summary_path.exists():
+            continue
+        try:
+            with summary_path.open("r", encoding="utf-8") as handle:
+                summary = json.load(handle)
+        except json.JSONDecodeError:
+            continue
+
+        context: dict[str, Any] = {}
+        if context_path.exists():
+            try:
+                with context_path.open("r", encoding="utf-8") as handle:
+                    context = json.load(handle)
+            except json.JSONDecodeError:
+                context = {}
+
+        results = summary.get("results", [])
+        status_counts: dict[str, int] = {}
+        for item in results:
+            status = str(item.get("status", "unknown"))
+            status_counts[status] = status_counts.get(status, 0) + 1
+
+        runs.append(
+            {
+                "runId": summary.get("run_id", run_dir.name),
+                "success": bool(summary.get("success", False)),
+                "artifactsDir": str(run_dir),
+                "request": context.get("user_request", ""),
+                "repoPath": context.get("repo_path", ""),
+                "stepCount": len(summary.get("plan", [])),
+                "resultCount": len(results),
+                "statusCounts": status_counts,
+                "updatedAt": datetime.fromtimestamp(run_dir.stat().st_mtime, timezone.utc).isoformat(),
+            }
+        )
+    return runs
+
+
+def _safe_run_path(run_dir: Path, relative_path: str) -> Path:
+    if not relative_path:
+        raise ValueError("Artifact path is required.")
+    candidate = (run_dir / relative_path).resolve()
+    run_root = run_dir.resolve()
+    if run_root not in candidate.parents and candidate != run_root:
+        raise ValueError("Artifact path escapes run directory.")
+    if not candidate.exists() or not candidate.is_file():
+        raise FileNotFoundError(f"Artifact file not found: {relative_path}")
+    return candidate
+
+
+def _list_run_files(run_dir: Path, limit: int = 200) -> list[dict[str, Any]]:
+    if not run_dir.exists():
+        return []
+    files: list[dict[str, Any]] = []
+    for path in sorted([item for item in run_dir.rglob("*") if item.is_file()])[:limit]:
+        relative = path.relative_to(run_dir).as_posix()
+        suffix = path.suffix.lower().lstrip(".")
+        files.append(
+            {
+                "path": relative,
+                "size": path.stat().st_size,
+                "kind": suffix or "file",
+            }
+        )
+    return files
+
+
+def _load_run_workspace_manifests(run_dir: Path) -> list[dict[str, Any]]:
+    workspaces_dir = run_dir / "workspaces"
+    manifests: list[dict[str, Any]] = []
+    if not workspaces_dir.exists():
+        return manifests
+    for path in sorted(workspaces_dir.glob("*.json")):
+        try:
+            with path.open("r", encoding="utf-8") as handle:
+                manifests.append(json.load(handle))
+        except json.JSONDecodeError:
+            continue
+    return manifests
+
+
+def _read_artifact_file(run_dir: Path, relative_path: str, limit: int = 200_000) -> dict[str, Any]:
+    target = _safe_run_path(run_dir, relative_path)
+    raw = target.read_bytes()
+    truncated = False
+    if len(raw) > limit:
+        raw = raw[:limit]
+        truncated = True
+    try:
+        content = raw.decode("utf-8")
+        encoding = "utf-8"
+    except UnicodeDecodeError:
+        content = raw.decode("utf-8", errors="replace")
+        encoding = "utf-8-replaced"
+    return {
+        "path": relative_path,
+        "content": content,
+        "truncated": truncated,
+        "size": target.stat().st_size,
+        "encoding": encoding,
+    }
+
+
+def _run_cleanup_command(command: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return {
+        "command": command,
+        "ok": result.returncode == 0,
+        "exitCode": result.returncode,
+        "stdout": result.stdout.strip(),
+        "stderr": result.stderr.strip(),
+    }
+
+
+def _cleanup_run_resources(
+    run_dir: Path,
+    *,
+    remove_worktrees: bool,
+    remove_artifacts: bool,
+) -> dict[str, Any]:
+    operations: list[dict[str, Any]] = []
+    manifests = _load_run_workspace_manifests(run_dir)
+
+    if remove_worktrees:
+        for manifest in manifests:
+            metadata = manifest.get("metadata") or {}
+            strategy = str(metadata.get("workspace_strategy", "")).strip()
+            if strategy != "git-worktree":
+                continue
+
+            workspace_path = str(manifest.get("workspace_path", "")).strip()
+            branch_name = str(manifest.get("branch_name", "")).strip()
+            repo_root = str(metadata.get("workspace_repo_root", "")).strip()
+            if not repo_root:
+                continue
+
+            if workspace_path and os.path.exists(workspace_path):
+                operations.append(
+                    {
+                        "type": "worktree_remove",
+                        "workspacePath": workspace_path,
+                        **_run_cleanup_command(
+                            ["git", "-C", repo_root, "worktree", "remove", "--force", workspace_path]
+                        ),
+                    }
+                )
+
+            if branch_name and branch_name.startswith("openclaw-"):
+                operations.append(
+                    {
+                        "type": "branch_delete",
+                        "branchName": branch_name,
+                        **_run_cleanup_command(["git", "-C", repo_root, "branch", "-D", branch_name]),
+                    }
+                )
+
+    if remove_artifacts and run_dir.exists():
+        shutil.rmtree(run_dir, ignore_errors=False)
+        operations.append(
+            {
+                "type": "artifacts_delete",
+                "path": str(run_dir),
+                "ok": True,
+                "exitCode": 0,
+                "stdout": "",
+                "stderr": "",
+            }
+        )
+
+    return {
+        "runId": run_dir.name,
+        "removedArtifacts": remove_artifacts,
+        "attemptedWorktreeCleanup": remove_worktrees,
+        "operations": operations,
+    }
+
+
+def _command_snapshot(
+    command: list[str],
+    *,
+    timeout_seconds: float = 20.0,
+) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            command,
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as error:
+        return {
+            "ok": False,
+            "command": command,
+            "exitCode": None,
+            "stdout": "",
+            "stderr": str(error),
+        }
+    except subprocess.TimeoutExpired as error:
+        return {
+            "ok": False,
+            "command": command,
+            "exitCode": None,
+            "stdout": error.stdout or "",
+            "stderr": error.stderr or f"Timed out after {timeout_seconds} seconds.",
+        }
+    return {
+        "ok": result.returncode == 0,
+        "command": command,
+        "exitCode": result.returncode,
+        "stdout": result.stdout,
+        "stderr": result.stderr,
+    }
+
+
+def _openclaw_health_snapshot(agent_id: str) -> dict[str, Any]:
+    health_capture = _command_snapshot(["openclaw", "health", "--json"], timeout_seconds=30.0)
+    gateway_capture = _command_snapshot(["openclaw", "gateway", "status"], timeout_seconds=15.0)
+    memory_capture = _command_snapshot(
+        ["openclaw", "memory", "status", "--deep", "--agent", agent_id],
+        timeout_seconds=30.0,
+    )
+
+    health_payload: dict[str, Any] = {}
+    if health_capture["stdout"]:
+        try:
+            health_payload = json.loads(health_capture["stdout"])
+        except json.JSONDecodeError:
+            health_payload = {}
+
+    channels: list[dict[str, Any]] = []
+    for channel_name in health_payload.get("channelOrder", []):
+        channel_data = (health_payload.get("channels") or {}).get(channel_name, {})
+        probe = channel_data.get("probe") or {}
+        channels.append(
+            {
+                "name": channel_name,
+                "label": (health_payload.get("channelLabels") or {}).get(channel_name, channel_name),
+                "configured": bool(channel_data.get("configured")),
+                "running": bool(channel_data.get("running")),
+                "probeOk": bool(probe.get("ok")),
+                "lastError": channel_data.get("lastError"),
+            }
+        )
+
+    agent_ids = [str(item.get("agentId", "")) for item in health_payload.get("agents", [])]
+    return {
+        "checkedAt": _utc_now(),
+        "agentId": agent_id,
+        "healthOk": bool(health_payload.get("ok")),
+        "defaultAgentId": health_payload.get("defaultAgentId", ""),
+        "knownAgents": [agent_id for agent_id in agent_ids if agent_id],
+        "targetAgentPresent": agent_id in agent_ids,
+        "channels": channels,
+        "healthRaw": health_payload,
+        "gateway": gateway_capture,
+        "memory": memory_capture,
+    }
+
+
+def _git_status_snapshot(repo_path: str) -> dict[str, Any]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo_path, "status", "--short", "--branch"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError) as error:
+        return {
+            "ok": False,
+            "summary": str(error),
+            "branch": "",
+            "dirty": False,
+            "changedFiles": [],
+        }
+
+    lines = [line.rstrip() for line in result.stdout.splitlines() if line.rstrip()]
+    branch = ""
+    changed_files: list[str] = []
+    if lines and lines[0].startswith("## "):
+        branch = lines[0][3:]
+        lines = lines[1:]
+    for line in lines:
+        if len(line) > 3:
+            changed_files.append(line[3:])
+    return {
+        "ok": True,
+        "summary": branch or "git status available",
+        "branch": branch,
+        "dirty": bool(changed_files),
+        "changedFiles": changed_files,
+    }
+
+
+def _serialize_plan_for_ui(plan: list[Any]) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    for step in plan:
+        items.append(
+            {
+                "id": step.id,
+                "title": step.title,
+                "mode": step.mode.value,
+                "agent": step.agent.value,
+                "profile": step.profile,
+                "assignment": step.assignment,
+                "managedAgent": step.managed_agent,
+                "dependsOn": step.depends_on,
+                "fallbackUsed": step.fallback_used,
+                "fallbackChain": step.fallback_chain,
+                "assignmentReason": step.assignment_reason,
+                "planningBlockedReason": step.planning_blocked_reason,
+                "requiredCapabilities": step.required_capabilities,
+            }
+        )
+    return items
+
+
+def _serialize_config_snapshot(config: Any, plan: list[Any]) -> dict[str, Any]:
+    return {
+        "runtime": _json_ready(config.runtime),
+        "github": _json_ready(config.github),
+        "defaultPipeline": config.runtime.pipeline,
+        "pipelines": {
+            name: [
+                {
+                    "id": step.id,
+                    "title": step.title,
+                    "dependsOn": step.depends_on,
+                    "assignment": step.assignment,
+                    "profile": step.profile,
+                    "metadata": step.metadata,
+                }
+                for step in steps
+            ]
+            for name, steps in config.pipelines.items()
+        },
+        "managedAgents": {
+            name: _json_ready(agent)
+            for name, agent in sorted(config.managed_agents.items())
+        },
+        "assignments": {
+            name: _json_ready(item)
+            for name, item in sorted(config.assignments.items())
+        },
+        "currentPlan": _serialize_plan_for_ui(plan),
+    }
+
+
+def _validate_live_policy(
+    orchestrator: HybridOrchestrator,
+    selected_steps: list[str] | None,
+    require_step_selection: bool,
+    allow_fallback_in_live: bool,
+    allowed_live_steps: list[str],
+) -> None:
+    if require_step_selection and not selected_steps:
+        raise ValueError(
+            "Live mode requires explicit steps. Select one or more steps before launching."
+        )
+
+    effective_plan = orchestrator.build_plan(selected_steps=selected_steps)
+    allowed_set = set(allowed_live_steps)
+    disallowed = [item.id for item in effective_plan if item.id not in allowed_set]
+    if disallowed:
+        raise ValueError(
+            "Live mode blocked by allowed_live_steps policy. "
+            f"Disallowed steps: {', '.join(disallowed)}."
+        )
+
+    if not allow_fallback_in_live:
+        fallback_items = [item for item in effective_plan if item.fallback_used]
+        if fallback_items:
+            details = ", ".join(
+                f"{item.id} -> {item.managed_agent or 'unknown'}"
+                for item in fallback_items
+            )
+            raise ValueError(
+                "Live mode blocked because fallback managed agents were selected. "
+                f"Steps: {details}."
+            )
+
+
+@dataclass
+class DashboardTask:
+    id: str
+    action: str
+    payload: dict[str, Any]
+    created_at: str
+    status: str = "queued"
+    progress: list[dict[str, str]] = field(default_factory=list)
+    result: dict[str, Any] | None = None
+    error: str = ""
+    runner: asyncio.Task[None] | None = None
+    subscribers: list[asyncio.Queue[dict[str, Any]]] = field(default_factory=list)
+
+    def add_progress(self, message: str) -> None:
+        self.progress.append({"at": _utc_now(), "message": message})
+        if len(self.progress) > 400:
+            self.progress = self.progress[-400:]
+        self.publish()
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "id": self.id,
+            "action": self.action,
+            "status": self.status,
+            "createdAt": self.created_at,
+            "progress": self.progress,
+            "error": self.error,
+            "payload": self.payload,
+            "result": self.result if self.status in {"completed", "failed"} else None,
+        }
+
+    def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
+        queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue()
+        self.subscribers.append(queue)
+        queue.put_nowait(self.to_payload())
+        return queue
+
+    def unsubscribe(self, queue: asyncio.Queue[dict[str, Any]]) -> None:
+        if queue in self.subscribers:
+            self.subscribers.remove(queue)
+
+    def publish(self) -> None:
+        payload = self.to_payload()
+        stale: list[asyncio.Queue[dict[str, Any]]] = []
+        for queue in self.subscribers:
+            try:
+                queue.put_nowait(payload)
+            except asyncio.QueueFull:
+                stale.append(queue)
+        for queue in stale:
+            self.unsubscribe(queue)
+
+
+class DashboardTaskManager:
+    def __init__(self, app: web.Application) -> None:
+        self.app = app
+        self.tasks: dict[str, DashboardTask] = {}
+        self._run_lock = asyncio.Lock()
+
+    def submit(self, action: str, payload: dict[str, Any]) -> DashboardTask:
+        task = DashboardTask(
+            id=uuid.uuid4().hex[:12],
+            action=action,
+            payload=payload,
+            created_at=_utc_now(),
+        )
+        task.add_progress("Queued.")
+        task.runner = asyncio.create_task(self._execute(task))
+        self.tasks[task.id] = task
+        if len(self.tasks) > 30:
+            stale = sorted(self.tasks.values(), key=lambda item: item.created_at)[:-30]
+            for item in stale:
+                if item.runner and not item.runner.done():
+                    continue
+                self.tasks.pop(item.id, None)
+        return task
+
+    async def _execute(self, task: DashboardTask) -> None:
+        try:
+            if task.action == "run":
+                task.add_progress("Waiting for execution slot.")
+                async with self._run_lock:
+                    task.status = "running"
+                    task.publish()
+                    task.result = await _execute_dashboard_action(self.app, task)
+            else:
+                task.status = "running"
+                task.publish()
+                task.result = await _execute_dashboard_action(self.app, task)
+            task.status = "completed"
+            task.add_progress("Completed.")
+            task.publish()
+        except asyncio.CancelledError:
+            task.status = "cancelled"
+            task.error = "Cancelled by user."
+            task.add_progress("Cancelled.")
+            task.publish()
+        except Exception as error:
+            task.status = "failed"
+            task.error = str(error)
+            task.add_progress(f"Failed: {error}")
+            task.publish()
+
+    def cancel(self, task_id: str) -> DashboardTask:
+        task = self.tasks.get(task_id)
+        if task is None:
+            raise KeyError(task_id)
+        if task.status in {"completed", "failed", "cancelled"}:
+            return task
+        task.add_progress("Cancellation requested.")
+        if task.runner is not None and not task.runner.done():
+            task.runner.cancel()
+        return task
+
+    async def shutdown(self) -> None:
+        pending = [
+            item.runner
+            for item in self.tasks.values()
+            if item.runner is not None and not item.runner.done()
+        ]
+        for runner in pending:
+            runner.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+
+
+def _resolve_request_payload(
+    app: web.Application,
+    payload: dict[str, Any],
+) -> tuple[str, str, Any]:
+    default_repo_path = str(app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(str(payload.get("repoPath", "")).strip(), default_repo_path)
+    config_path = _resolve_user_path(
+        str(payload.get("configPath", "")).strip() or str(app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    config = load_app_config(config_path)
+    pipeline = str(payload.get("pipeline", "")).strip()
+    if pipeline:
+        config.runtime.pipeline = pipeline
+    return repo_path, config_path, config
+
+
+async def _execute_dashboard_action(
+    app: web.Application,
+    task: DashboardTask,
+) -> dict[str, Any]:
+    payload = task.payload
+    repo_path, config_path, config = _resolve_request_payload(app, payload)
+    selected_steps = _selected_steps(payload)
+
+    if task.action == "doctor":
+        task.add_progress("Running config diagnostics.")
+        report = diagnose_app_config(config)
+        return {
+            "mode": "doctor",
+            "configPath": config_path,
+            "checks": _json_ready(report),
+        }
+
+    orchestrator = HybridOrchestrator(config)
+
+    if task.action in {"diagnose", "preflight"}:
+        task.add_progress("Running preflight.")
+        plan, report = await orchestrator.preflight(repo_path, selected_steps=selected_steps)
+        return {
+            "mode": task.action,
+            "repoPath": repo_path,
+            "configPath": config_path,
+            "pipeline": config.runtime.pipeline,
+            "selectedSteps": selected_steps or [],
+            "plan": _serialize_plan_for_ui(plan),
+            "preflight": _json_ready(report),
+        }
+
+    if task.action != "run":
+        raise ValueError(f"Unsupported dashboard action: {task.action}")
+
+    user_request = str(payload.get("request", "")).strip()
+    if not user_request:
+        raise ValueError("Request text is required before running the pipeline.")
+
+    live = bool(payload.get("live", False))
+    config.runtime.dry_run = not live
+    orchestrator = HybridOrchestrator(config)
+    if live:
+        _validate_live_policy(
+            orchestrator,
+            selected_steps=selected_steps,
+            require_step_selection=config.runtime.require_step_selection_for_live,
+            allow_fallback_in_live=config.runtime.allow_fallback_in_live,
+            allowed_live_steps=config.runtime.allowed_live_steps,
+        )
+
+    task.add_progress(
+        f"Launching {config.runtime.pipeline} in {'live' if live else 'dry-run'} mode."
+    )
+    result = await orchestrator.run(
+        user_request,
+        repo_path,
+        selected_steps=selected_steps,
+        progress_callback=task.add_progress,
+    )
+    history = _read_run_history(repo_path, config_path, result.run_id)
+    return {
+        "mode": "run",
+        "repoPath": repo_path,
+        "configPath": config_path,
+        "pipeline": config.runtime.pipeline,
+        "selectedSteps": selected_steps or [],
+        "live": live,
+        "runResult": _json_ready(result),
+        "preflight": _load_preflight_report(result.artifacts_dir),
+        "history": history,
+    }
+
+
+def _read_run_history(
+    repo_path: str,
+    config_path: str,
+    run_id: str,
+) -> dict[str, Any]:
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
+        raise ValueError("Invalid run id.")
+
+    config = load_app_config(config_path)
+    artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
+    run_dir = Path(artifacts_root) / run_id
+    summary_path = run_dir / "summary.json"
+    if not summary_path.exists():
+        raise FileNotFoundError(f"Run summary not found for {run_id}.")
+
+    with summary_path.open("r", encoding="utf-8") as handle:
+        summary = json.load(handle)
+
+    context_path = run_dir / "context.json"
+    context = {}
+    if context_path.exists():
+        with context_path.open("r", encoding="utf-8") as handle:
+            context = json.load(handle)
+
+    preflight = _load_preflight_report(str(run_dir))
+    return {
+        "runId": run_id,
+        "artifactsDir": str(run_dir),
+        "context": context,
+        "summary": summary,
+        "preflight": preflight,
+        "files": _list_run_files(run_dir),
+    }
+
+
+def _cleanup_run_history(
+    repo_path: str,
+    config_path: str,
+    run_id: str,
+    *,
+    remove_worktrees: bool,
+    remove_artifacts: bool,
+) -> dict[str, Any]:
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
+        raise ValueError("Invalid run id.")
+    config = load_app_config(config_path)
+    artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
+    run_dir = Path(artifacts_root) / run_id
+    if not run_dir.exists():
+        raise FileNotFoundError(f"Run directory not found for {run_id}.")
+    return _cleanup_run_resources(
+        run_dir,
+        remove_worktrees=remove_worktrees,
+        remove_artifacts=remove_artifacts,
+    )
+
+
+def _prune_run_history(
+    repo_path: str,
+    config_path: str,
+    *,
+    keep_latest: int,
+    remove_worktrees: bool,
+    remove_artifacts: bool,
+) -> dict[str, Any]:
+    config = load_app_config(config_path)
+    artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
+    root = Path(artifacts_root)
+    if not root.exists():
+        return {
+            "artifactsRoot": artifacts_root,
+            "keepLatest": keep_latest,
+            "removed": [],
+        }
+
+    run_dirs = sorted(
+        [path for path in root.iterdir() if path.is_dir() and path.name.startswith("run-")],
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    removed: list[dict[str, Any]] = []
+    for run_dir in run_dirs[keep_latest:]:
+        removed.append(
+            _cleanup_run_resources(
+                run_dir,
+                remove_worktrees=remove_worktrees,
+                remove_artifacts=remove_artifacts,
+            )
+        )
+    return {
+        "artifactsRoot": artifacts_root,
+        "keepLatest": keep_latest,
+        "removed": removed,
+    }
+
+
+async def _index_handler(request: web.Request) -> web.StreamResponse:
+    static_root = Path(request.app[APP_STATIC_ROOT])
+    return web.FileResponse(static_root / "index.html")
+
+
+async def _bootstrap_handler(request: web.Request) -> web.Response:
+    default_repo = str(request.app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(request.query.get("repoPath", ""), default_repo)
+    config_path = _resolve_user_path(
+        request.query.get("configPath", "") or str(request.app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    config = load_app_config(config_path)
+    pipeline = request.query.get("pipeline", "").strip()
+    if pipeline:
+        config.runtime.pipeline = pipeline
+    orchestrator = HybridOrchestrator(config)
+    plan = orchestrator.build_plan()
+    artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
+    payload = {
+        "repoPath": repo_path,
+        "configPath": config_path,
+        "git": _git_status_snapshot(repo_path),
+        "artifactsRoot": artifacts_root,
+        "defaultOpenClawAgentId": _default_openclaw_agent_id(config),
+        "snapshot": _serialize_config_snapshot(config, plan),
+        "recentRuns": _summarize_recent_runs(artifacts_root),
+    }
+    return web.json_response(payload)
+
+
+async def _task_create_handler(request: web.Request) -> web.Response:
+    payload = await request.json()
+    action = str(payload.get("action", "")).strip()
+    if action not in {"diagnose", "preflight", "doctor", "run"}:
+        raise web.HTTPBadRequest(text="Unsupported action.")
+    task = request.app[APP_TASK_MANAGER].submit(action, payload)
+    return web.json_response({"task": task.to_payload()}, status=202)
+
+
+async def _task_detail_handler(request: web.Request) -> web.Response:
+    task_id = request.match_info["task_id"]
+    task = request.app[APP_TASK_MANAGER].tasks.get(task_id)
+    if task is None:
+        raise web.HTTPNotFound(text="Task not found.")
+    return web.json_response({"task": task.to_payload()})
+
+
+async def _task_cancel_handler(request: web.Request) -> web.Response:
+    task_id = request.match_info["task_id"]
+    try:
+        task = request.app[APP_TASK_MANAGER].cancel(task_id)
+    except KeyError as error:
+        raise web.HTTPNotFound(text="Task not found.") from error
+    return web.json_response({"task": task.to_payload()})
+
+
+async def _task_events_handler(request: web.Request) -> web.StreamResponse:
+    task_id = request.match_info["task_id"]
+    task = request.app[APP_TASK_MANAGER].tasks.get(task_id)
+    if task is None:
+        raise web.HTTPNotFound(text="Task not found.")
+
+    response = web.StreamResponse(
+        status=200,
+        headers={
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+        },
+    )
+    await response.prepare(request)
+
+    queue = task.subscribe()
+    try:
+        while True:
+            try:
+                payload = await asyncio.wait_for(queue.get(), timeout=15.0)
+            except asyncio.TimeoutError:
+                await response.write(b": heartbeat\n\n")
+                continue
+            data = json.dumps({"task": payload}, ensure_ascii=False)
+            await response.write(f"event: task\ndata: {data}\n\n".encode("utf-8"))
+            if payload["status"] in {"completed", "failed", "cancelled"}:
+                break
+    except (ConnectionResetError, asyncio.CancelledError):
+        pass
+    finally:
+        task.unsubscribe(queue)
+    return response
+
+
+async def _history_handler(request: web.Request) -> web.Response:
+    default_repo = str(request.app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(request.query.get("repoPath", ""), default_repo)
+    config_path = _resolve_user_path(
+        request.query.get("configPath", "") or str(request.app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    run_id = request.match_info["run_id"]
+    try:
+        payload = _read_run_history(repo_path, config_path, run_id)
+    except FileNotFoundError as error:
+        raise web.HTTPNotFound(text=str(error)) from error
+    except ValueError as error:
+        raise web.HTTPBadRequest(text=str(error)) from error
+    return web.json_response(payload)
+
+
+async def _history_file_handler(request: web.Request) -> web.Response:
+    default_repo = str(request.app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(request.query.get("repoPath", ""), default_repo)
+    config_path = _resolve_user_path(
+        request.query.get("configPath", "") or str(request.app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    run_id = request.match_info["run_id"]
+    relative_path = request.query.get("path", "")
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
+        raise web.HTTPBadRequest(text="Invalid run id.")
+    config = load_app_config(config_path)
+    artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
+    run_dir = Path(artifacts_root) / run_id
+    try:
+        payload = _read_artifact_file(run_dir, relative_path)
+    except FileNotFoundError as error:
+        raise web.HTTPNotFound(text=str(error)) from error
+    except ValueError as error:
+        raise web.HTTPBadRequest(text=str(error)) from error
+    return web.json_response({"runId": run_id, **payload})
+
+
+async def _history_cleanup_handler(request: web.Request) -> web.Response:
+    default_repo = str(request.app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(request.query.get("repoPath", ""), default_repo)
+    config_path = _resolve_user_path(
+        request.query.get("configPath", "") or str(request.app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    run_id = request.match_info["run_id"]
+    body = await request.json() if request.can_read_body else {}
+    remove_worktrees = bool(body.get("removeWorktrees", True))
+    remove_artifacts = bool(body.get("removeArtifacts", True))
+    try:
+        payload = await asyncio.to_thread(
+            _cleanup_run_history,
+            repo_path,
+            config_path,
+            run_id,
+            remove_worktrees=remove_worktrees,
+            remove_artifacts=remove_artifacts,
+        )
+    except FileNotFoundError as error:
+        raise web.HTTPNotFound(text=str(error)) from error
+    except ValueError as error:
+        raise web.HTTPBadRequest(text=str(error)) from error
+    return web.json_response(payload)
+
+
+async def _history_prune_handler(request: web.Request) -> web.Response:
+    default_repo = str(request.app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(request.query.get("repoPath", ""), default_repo)
+    config_path = _resolve_user_path(
+        request.query.get("configPath", "") or str(request.app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    body = await request.json() if request.can_read_body else {}
+    keep_latest = max(0, int(body.get("keepLatest", 10)))
+    remove_worktrees = bool(body.get("removeWorktrees", True))
+    remove_artifacts = bool(body.get("removeArtifacts", True))
+    payload = await asyncio.to_thread(
+        _prune_run_history,
+        repo_path,
+        config_path,
+        keep_latest=keep_latest,
+        remove_worktrees=remove_worktrees,
+        remove_artifacts=remove_artifacts,
+    )
+    return web.json_response(payload)
+
+
+async def _health_handler(request: web.Request) -> web.Response:
+    default_repo = str(request.app[APP_REPO_PATH])
+    repo_path = _resolve_user_path(request.query.get("repoPath", ""), default_repo)
+    config_path = _resolve_user_path(
+        request.query.get("configPath", "") or str(request.app[APP_CONFIG_PATH]),
+        repo_path,
+    )
+    config = load_app_config(config_path)
+    agent_id = request.query.get("agentId", "").strip() or _default_openclaw_agent_id(config)
+    payload = await asyncio.to_thread(_openclaw_health_snapshot, agent_id)
+    return web.json_response(payload)
+
+
+async def _cleanup_background_tasks(app: web.Application) -> None:
+    task_manager = app[APP_TASK_MANAGER]
+    await task_manager.shutdown()
+
+
+def create_web_app(
+    *,
+    config_path: str,
+    repo_path: str,
+) -> web.Application:
+    static_root = Path(__file__).with_name("webui")
+    app = web.Application()
+    app[APP_CONFIG_PATH] = config_path
+    app[APP_REPO_PATH] = repo_path
+    app[APP_STATIC_ROOT] = str(static_root)
+    app[APP_TASK_MANAGER] = DashboardTaskManager(app)
+
+    app.router.add_get("/", _index_handler)
+    app.router.add_get("/api/bootstrap", _bootstrap_handler)
+    app.router.add_post("/api/tasks", _task_create_handler)
+    app.router.add_get("/api/tasks/{task_id}", _task_detail_handler)
+    app.router.add_post("/api/tasks/{task_id}/cancel", _task_cancel_handler)
+    app.router.add_get("/api/tasks/{task_id}/events", _task_events_handler)
+    app.router.add_get("/api/history/{run_id}", _history_handler)
+    app.router.add_get("/api/history/{run_id}/file", _history_file_handler)
+    app.router.add_post("/api/history/{run_id}/cleanup", _history_cleanup_handler)
+    app.router.add_post("/api/history/prune", _history_prune_handler)
+    app.router.add_get("/api/system/health", _health_handler)
+    app.router.add_static("/static/", str(static_root))
+    app.on_cleanup.append(_cleanup_background_tasks)
+    return app
+
+
+async def run_web_server(
+    *,
+    config_path: str,
+    repo_path: str,
+    host: str,
+    port: int,
+) -> None:
+    app = create_web_app(config_path=config_path, repo_path=repo_path)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host=host, port=port)
+    await site.start()
+    print("OpenClaw Mission Control Web UI is running.")
+    print(f"Dashboard: http://{host}:{port}/")
+    print(f"Repo: {repo_path}")
+    print(f"Config: {config_path}")
+    stop_event = asyncio.Event()
+    try:
+        await stop_event.wait()
+    except asyncio.CancelledError:
+        pass
+    finally:
+        await runner.cleanup()

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -1,0 +1,1348 @@
+const state = {
+  bootstrap: null,
+  currentTaskId: null,
+  taskStream: null,
+  live: false,
+  currentHistory: null,
+  healthSnapshot: null,
+  currentOutput: null,
+  resultFilter: "all",
+};
+
+const elements = {
+  repoPath: document.getElementById("repo-path"),
+  configPath: document.getElementById("config-path"),
+  pipeline: document.getElementById("pipeline"),
+  request: document.getElementById("request"),
+  stepGrid: document.getElementById("step-grid"),
+  refreshBootstrap: document.getElementById("refresh-bootstrap"),
+  modeToggle: document.getElementById("mode-toggle"),
+  workspaceMetrics: document.getElementById("workspace-metrics"),
+  heroStatus: document.getElementById("hero-status"),
+  recentRuns: document.getElementById("recent-runs"),
+  pruneKeepLatest: document.getElementById("prune-keep-latest"),
+  pruneRuns: document.getElementById("prune-runs"),
+  housekeepingStatus: document.getElementById("housekeeping-status"),
+  healthAgentId: document.getElementById("health-agent-id"),
+  checkHealth: document.getElementById("check-health"),
+  healthPanel: document.getElementById("health-panel"),
+  taskState: document.getElementById("task-state"),
+  cancelTask: document.getElementById("cancel-task"),
+  taskMeta: document.getElementById("task-meta"),
+  taskProgress: document.getElementById("task-progress"),
+  outputPane: document.getElementById("output-pane"),
+  resultFilter: document.getElementById("result-filter"),
+  copyRunSummary: document.getElementById("copy-run-summary"),
+  copyIssueUpdate: document.getElementById("copy-issue-update"),
+  copyPrNote: document.getElementById("copy-pr-note"),
+  copyFeedback: document.getElementById("copy-feedback"),
+  artifactContext: document.getElementById("artifact-context"),
+  cleanupCurrentRun: document.getElementById("cleanup-current-run"),
+  artifactList: document.getElementById("artifact-list"),
+  artifactViewer: document.getElementById("artifact-viewer"),
+  readinessStateSlot: document.getElementById("readiness-state-slot"),
+  readinessSummary: document.getElementById("readiness-summary"),
+  readinessChecks: document.getElementById("readiness-checks"),
+  selectAll: document.getElementById("select-all"),
+  selectNone: document.getElementById("select-none"),
+  buttons: Array.from(document.querySelectorAll("[data-action]")),
+  taskStateSlot: document.getElementById("task-state-slot"),
+};
+
+function escapeHtml(value) {
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function makeStatusChip(value) {
+  const normalized = String(value || "neutral").toLowerCase();
+  return `<span class="status-chip ${normalized}">${escapeHtml(normalized)}</span>`;
+}
+
+function setCopyFeedback(message) {
+  elements.copyFeedback.textContent = message;
+}
+
+function statusCounts(results) {
+  const counts = {};
+  for (const item of results || []) {
+    counts[item.status] = (counts[item.status] || 0) + 1;
+  }
+  return counts;
+}
+
+function formatCounts(counts) {
+  const entries = Object.entries(counts || {});
+  if (!entries.length) {
+    return "no step results";
+  }
+  return entries.map(([key, value]) => `${key}:${value}`).join(" · ");
+}
+
+function actionableResults(results) {
+  return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
+}
+
+function filterResults(results) {
+  const all = results || [];
+  switch (state.resultFilter) {
+    case "actionable":
+      return actionableResults(all);
+    case "failed-blocked":
+      return all.filter((item) => ["failed", "blocked"].includes(item.status));
+    case "skipped":
+      return all.filter((item) => item.status === "skipped");
+    case "succeeded":
+      return all.filter((item) => item.status === "succeeded");
+    default:
+      return all;
+  }
+}
+
+function extractRunPayload(payload) {
+  if (!payload) {
+    return null;
+  }
+  if (payload.runResult) {
+    return {
+      runResult: payload.runResult,
+      history: payload.history || null,
+      pipeline: payload.pipeline || "",
+      request: payload.history?.context?.user_request || "",
+    };
+  }
+  if (payload.summary) {
+    return {
+      runResult: payload.summary,
+      history: payload,
+      pipeline: "",
+      request: payload.context?.user_request || "",
+    };
+  }
+  return null;
+}
+
+function primaryBranch(runResult) {
+  for (const item of runResult?.results || []) {
+    const artifacts = item.artifacts || {};
+    if (artifacts.source_branch) {
+      return artifacts.source_branch;
+    }
+    if (artifacts.branch_name) {
+      return artifacts.branch_name;
+    }
+  }
+  return "";
+}
+
+function currentPipelineSteps() {
+  const pipelines = state.bootstrap?.snapshot?.pipelines || {};
+  return pipelines[elements.pipeline.value] || [];
+}
+
+function currentPlanMap() {
+  return new Map(
+    ((state.bootstrap?.snapshot?.currentPlan || []).map((step) => [step.id, step])),
+  );
+}
+
+function effectiveStepIds() {
+  const pipelineSteps = currentPipelineSteps();
+  if (!pipelineSteps.length) {
+    return [];
+  }
+
+  const stepMap = new Map(pipelineSteps.map((step) => [step.id, step]));
+  const explicitSelection = selectedSteps();
+  const seed = explicitSelection.length ? explicitSelection : pipelineSteps.map((step) => step.id);
+  const included = new Set();
+
+  function includeStep(stepId) {
+    if (!stepId || included.has(stepId)) {
+      return;
+    }
+    included.add(stepId);
+    const step = stepMap.get(stepId);
+    for (const dependency of step?.dependsOn || []) {
+      includeStep(dependency);
+    }
+  }
+
+  seed.forEach(includeStep);
+  return pipelineSteps.map((step) => step.id).filter((stepId) => included.has(stepId));
+}
+
+function effectivePlanItems() {
+  const planMap = currentPlanMap();
+  return effectiveStepIds().map((stepId) => {
+    const planItem = planMap.get(stepId);
+    if (planItem) {
+      return planItem;
+    }
+    const pipelineStep = currentPipelineSteps().find((step) => step.id === stepId) || {};
+    return {
+      id: pipelineStep.id || stepId,
+      title: pipelineStep.title || stepId,
+      mode: "",
+      agent: "",
+      profile: pipelineStep.profile || "",
+      assignment: pipelineStep.assignment || "",
+      managedAgent: "",
+      dependsOn: pipelineStep.dependsOn || [],
+      fallbackUsed: false,
+    };
+  });
+}
+
+function healthSnapshotIsCurrent() {
+  const requestedAgent = (elements.healthAgentId.value || "").trim();
+  if (!state.healthSnapshot) {
+    return false;
+  }
+  if (!requestedAgent) {
+    return true;
+  }
+  return state.healthSnapshot.agentId === requestedAgent;
+}
+
+function latestPreflightChecks() {
+  const sources = [
+    state.currentOutput?.preflight,
+    state.currentOutput?.history?.preflight,
+    state.currentHistory?.preflight,
+  ];
+  for (const source of sources) {
+    if (Array.isArray(source?.checks) && source.checks.length) {
+      return source.checks;
+    }
+  }
+  return [];
+}
+
+function overallStatus(checks) {
+  const statuses = (checks || []).map((item) => item.status);
+  if (statuses.some((status) => ["blocked", "failed"].includes(status))) {
+    return "blocked";
+  }
+  if (statuses.includes("warning")) {
+    return "warning";
+  }
+  if (statuses.includes("passed") && statuses.every((status) => ["passed", "neutral"].includes(status))) {
+    return "passed";
+  }
+  return "neutral";
+}
+
+function readinessFacts() {
+  const bootstrap = state.bootstrap || {};
+  const runtime = bootstrap.snapshot?.runtime || {};
+  const git = bootstrap.git || {};
+  const health = state.healthSnapshot;
+  const healthCurrent = healthSnapshotIsCurrent();
+  const selected = selectedSteps();
+  const effective = effectiveStepIds();
+  return [
+    {
+      label: "Repo",
+      status: git.dirty ? "warning" : "passed",
+      value: git.dirty ? "dirty" : "clean",
+      detail: git.branch || "branch unknown",
+    },
+    {
+      label: "Steps",
+      status: effective.length ? "passed" : "warning",
+      value: `${effective.length || 0} effective`,
+      detail: selected.length ? `${selected.length} explicitly selected` : "full pipeline active",
+    },
+    {
+      label: "OpenClaw",
+      status: !health ? "neutral" : healthCurrent ? (health.healthOk ? "passed" : "warning") : "warning",
+      value: !health ? "unchecked" : healthCurrent ? (health.healthOk ? "ready" : "warn") : "stale",
+      detail: (elements.healthAgentId.value || bootstrap.defaultOpenClawAgentId || "agent unknown"),
+    },
+    {
+      label: "Live policy",
+      status: runtime.allow_fallback_in_live ? "warning" : "passed",
+      value: runtime.allow_fallback_in_live ? "relaxed" : "strict",
+      detail: runtime.require_step_selection_for_live ? "explicit steps required" : "step selection optional",
+    },
+  ];
+}
+
+function renderReadinessGate() {
+  const bootstrap = state.bootstrap || {};
+  const runtime = bootstrap.snapshot?.runtime || {};
+  const git = bootstrap.git || {};
+  const health = state.healthSnapshot;
+  const healthCurrent = healthSnapshotIsCurrent();
+  const requestText = (elements.request.value || "").trim();
+  const pipelineSteps = currentPipelineSteps();
+  const explicitSelection = selectedSteps();
+  const effectiveIds = effectiveStepIds();
+  const planItems = effectivePlanItems();
+  const preflightChecks = latestPreflightChecks();
+  const allowedLiveSteps = Array.isArray(runtime.allowed_live_steps) ? runtime.allowed_live_steps : [];
+  const usesOpenClaw = planItems.some((item) => {
+    const mode = String(item.mode || "").toLowerCase();
+    const agent = String(item.agent || "").toLowerCase();
+    return mode === "openclaw" || agent === "openclaw";
+  });
+  const fallbackItems = planItems.filter((item) => item.fallbackUsed);
+  const preflightProblems = preflightChecks.filter((check) =>
+    ["blocked", "failed", "warning"].includes(String(check.status || "").toLowerCase()),
+  );
+  const liveDisallowed = state.live
+    ? effectiveIds.filter((stepId) => allowedLiveSteps.length && !allowedLiveSteps.includes(stepId))
+    : [];
+
+  const checks = [
+    {
+      name: "Request",
+      status: requestText ? "passed" : "blocked",
+      summary: requestText ? "Request text is ready." : "Add request text before launching a pipeline run.",
+      detail: requestText ? `${requestText.length} chars captured.` : "Diagnose and doctor can run without it, but pipeline execution cannot.",
+    },
+    {
+      name: "Step scope",
+      status: pipelineSteps.length
+        ? state.live && runtime.require_step_selection_for_live && !explicitSelection.length
+          ? "blocked"
+          : "passed"
+        : "warning",
+      summary: pipelineSteps.length
+        ? explicitSelection.length
+          ? `Selected ${explicitSelection.length} steps; ${effectiveIds.length} effective with dependencies.`
+          : `Using the full pipeline with ${effectiveIds.length} effective steps.`
+        : "No steps are available for the selected pipeline.",
+      detail: pipelineSteps.length
+        ? state.live && runtime.require_step_selection_for_live && !explicitSelection.length
+          ? "Live mode requires an explicit subset."
+          : `Pipeline: ${elements.pipeline.value || bootstrap.snapshot?.defaultPipeline || "n/a"}`
+        : "Refresh bootstrap or check config_v2.yaml.",
+    },
+    {
+      name: "Live policy",
+      status: !state.live
+        ? "neutral"
+        : liveDisallowed.length
+          ? "blocked"
+          : "passed",
+      summary: !state.live
+        ? "Dry-run ignores live launch restrictions."
+        : liveDisallowed.length
+          ? `Live launch is blocked by allowed_live_steps: ${liveDisallowed.join(", ")}.`
+          : "Effective steps satisfy the live allow-list.",
+      detail: allowedLiveSteps.length ? `Allowed: ${allowedLiveSteps.join(", ")}` : "No live allow-list configured.",
+    },
+    {
+      name: "Repo base",
+      status: git.ok === false ? "warning" : git.dirty ? "warning" : "passed",
+      summary:
+        git.ok === false
+          ? "Git status could not be read."
+          : git.dirty
+            ? "Working tree is dirty; isolated live steps may start from an unexpected base."
+            : "Working tree is clean.",
+      detail:
+        git.dirty && Array.isArray(git.changedFiles) && git.changedFiles.length
+          ? `${git.changedFiles.length} changed files detected.`
+          : git.branch || "Git branch unavailable.",
+    },
+    {
+      name: "OpenClaw route",
+      status: !usesOpenClaw
+        ? "neutral"
+        : !health
+          ? "warning"
+          : !healthCurrent
+            ? "warning"
+            : health.healthOk && health.targetAgentPresent
+              ? "passed"
+              : "blocked",
+      summary: !usesOpenClaw
+        ? "Current effective steps do not require the local OpenClaw executor."
+        : !health
+          ? "OpenClaw health has not been checked yet."
+          : !healthCurrent
+            ? `Health snapshot is stale for ${health.agentId}; refresh ${elements.healthAgentId.value || bootstrap.defaultOpenClawAgentId || "the target agent"}.`
+            : health.healthOk && health.targetAgentPresent
+              ? "OpenClaw target agent is reachable."
+              : "OpenClaw target agent is not ready.",
+      detail: usesOpenClaw
+        ? `Target agent: ${elements.healthAgentId.value || bootstrap.defaultOpenClawAgentId || "n/a"}`
+        : "No OpenClaw-only step selected.",
+    },
+    {
+      name: "Memory",
+      status: !usesOpenClaw
+        ? "neutral"
+        : !health || !healthCurrent
+          ? "warning"
+          : health.memory?.ok
+            ? "passed"
+            : "warning",
+      summary: !usesOpenClaw
+        ? "Embedding memory is not on the critical path for the current step set."
+        : !health || !healthCurrent
+          ? "Memory readiness has not been confirmed for the current agent."
+          : health.memory?.ok
+            ? "Embedding memory is ready."
+            : "Embedding memory returned warnings.",
+      detail: !usesOpenClaw
+        ? "No OpenClaw memory dependency detected."
+        : health?.memory?.stdout?.trim() || health?.memory?.stderr?.trim() || "No memory output captured.",
+    },
+    {
+      name: "Fallback resolution",
+      status: fallbackItems.length
+        ? state.live && runtime.allow_fallback_in_live === false
+          ? "blocked"
+          : "warning"
+        : "passed",
+      summary: fallbackItems.length
+        ? `${fallbackItems.length} steps currently resolve through fallback managed agents.`
+        : "No fallback managed agents detected in the current plan snapshot.",
+      detail: fallbackItems.length
+        ? fallbackItems
+            .map((item) => `${item.id} -> ${item.managedAgent || "unknown"}`)
+            .join(", ")
+        : "Assignment resolution is explicit.",
+    },
+    {
+      name: "Latest preflight",
+      status: !preflightChecks.length
+        ? "neutral"
+        : preflightProblems.some((item) => ["blocked", "failed"].includes(String(item.status || "").toLowerCase()))
+          ? "blocked"
+          : preflightProblems.length
+            ? "warning"
+            : "passed",
+      summary: !preflightChecks.length
+        ? "No preflight snapshot loaded yet."
+        : preflightProblems.length
+          ? `${preflightProblems.length} preflight checks need attention.`
+          : "Latest preflight snapshot is clean.",
+      detail: !preflightChecks.length
+        ? "Run Preflight or load a recent run to surface the last report here."
+        : `${preflightChecks.length} checks captured from the latest snapshot.`,
+    },
+  ];
+
+  const status = overallStatus(checks);
+  elements.readinessStateSlot.innerHTML = makeStatusChip(status);
+  elements.readinessSummary.textContent =
+    status === "passed"
+      ? "This launch configuration is in a good state for the selected mode."
+      : status === "warning"
+        ? "The configuration is usable, but a few cautions should be cleared first."
+        : status === "blocked"
+          ? "The current configuration has blockers that should be resolved before a live launch."
+          : "Readiness is waiting on more context.";
+  elements.readinessChecks.innerHTML = checks
+    .map(
+      (check) => `
+        <article class="check-row">
+          <div class="result-card-header">
+            <strong>${escapeHtml(check.name)}</strong>
+            ${makeStatusChip(check.status)}
+          </div>
+          <div>${escapeHtml(check.summary)}</div>
+          <small>${escapeHtml(check.detail)}</small>
+        </article>
+      `,
+    )
+    .join("");
+}
+
+function renderHeroStatus() {
+  const facts = readinessFacts();
+  elements.heroStatus.innerHTML = facts
+    .map(
+      (fact) => `
+        <div class="fact">
+          ${makeStatusChip(fact.status)}
+          <strong>${escapeHtml(fact.label)} · ${escapeHtml(fact.value)}</strong>
+          <div>${escapeHtml(fact.detail)}</div>
+        </div>
+      `,
+    )
+    .join("");
+}
+
+async function copyText(text, successMessage) {
+  if (!text) {
+    return;
+  }
+  if (navigator.clipboard && navigator.clipboard.writeText) {
+    await navigator.clipboard.writeText(text);
+    setCopyFeedback(successMessage);
+    return;
+  }
+  const area = document.createElement("textarea");
+  area.value = text;
+  document.body.appendChild(area);
+  area.select();
+  document.execCommand("copy");
+  document.body.removeChild(area);
+  setCopyFeedback(successMessage);
+}
+
+function setMode(live) {
+  state.live = Boolean(live);
+  elements.modeToggle.setAttribute("aria-pressed", state.live ? "true" : "false");
+  const copy = elements.modeToggle.querySelector(".toggle-copy");
+  copy.textContent = state.live ? "Live" : "Dry-run";
+  renderHeroStatus();
+  renderReadinessGate();
+}
+
+function selectedSteps() {
+  return Array.from(elements.stepGrid.querySelectorAll("input[type=checkbox]:checked")).map(
+    (input) => input.value,
+  );
+}
+
+function renderWorkspaceMetrics(bootstrap) {
+  const git = bootstrap.git || {};
+  const snapshot = bootstrap.snapshot || {};
+  const runtime = snapshot.runtime || {};
+  const metrics = [
+    ["Repo", bootstrap.repoPath],
+    ["Config", bootstrap.configPath],
+    ["Branch", git.branch || "unknown"],
+    ["Dirty", git.dirty ? "yes" : "no"],
+    ["Default pipeline", snapshot.defaultPipeline || "n/a"],
+    ["Artifacts", bootstrap.artifactsRoot || "n/a"],
+    ["Live policy", runtime.allow_fallback_in_live ? "fallback allowed" : "strict"],
+    ["Live steps", Array.isArray(runtime.allowed_live_steps) ? runtime.allowed_live_steps.join(", ") : "n/a"],
+  ];
+  elements.workspaceMetrics.innerHTML = metrics
+    .map(
+      ([label, value]) =>
+        `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`,
+    )
+    .join("");
+}
+
+function renderPipelines(bootstrap) {
+  const snapshot = bootstrap.snapshot || {};
+  const pipelines = snapshot.pipelines || {};
+  const currentPipeline = elements.pipeline.value || snapshot.defaultPipeline;
+  elements.pipeline.innerHTML = Object.keys(pipelines)
+    .map(
+      (name) =>
+        `<option value="${escapeHtml(name)}" ${name === currentPipeline ? "selected" : ""}>${escapeHtml(name)}</option>`,
+    )
+    .join("");
+}
+
+function renderStepGrid() {
+  const bootstrap = state.bootstrap;
+  if (!bootstrap) {
+    return;
+  }
+  const snapshot = bootstrap.snapshot || {};
+  const pipelines = snapshot.pipelines || {};
+  const steps = pipelines[elements.pipeline.value] || [];
+  const previousSelection = new Set(selectedSteps());
+  elements.stepGrid.innerHTML = steps.length
+    ? steps
+        .map((step) => {
+          const checked = previousSelection.has(step.id) ? "checked" : "";
+          const depends = (step.dependsOn || []).length
+            ? `Depends on: ${(step.dependsOn || []).join(", ")}`
+            : "Starts clean";
+          const route = step.assignment || step.profile || "n/a";
+          return `
+            <article class="step-card">
+              <label>
+                <input type="checkbox" value="${escapeHtml(step.id)}" ${checked} />
+                <span>
+                  <strong>${escapeHtml(step.id)}</strong>
+                  ${escapeHtml(step.title)}
+                </span>
+              </label>
+              <small>${escapeHtml(depends)}</small>
+              <small>Route: ${escapeHtml(route)}</small>
+            </article>
+          `;
+        })
+        .join("")
+    : `<div class="empty-state">No steps are defined for the selected pipeline.</div>`;
+
+  elements.stepGrid.querySelectorAll("input[type=checkbox]").forEach((input) => {
+    input.addEventListener("change", () => {
+      renderHeroStatus();
+      renderReadinessGate();
+    });
+  });
+}
+
+function renderRecentRuns(bootstrap) {
+  const runs = bootstrap.recentRuns || [];
+  if (!runs.length) {
+    elements.recentRuns.innerHTML = `<div class="empty-state">No recorded runs yet.</div>`;
+    return;
+  }
+  elements.recentRuns.innerHTML = runs
+    .map((run) => {
+      const counts = Object.entries(run.statusCounts || {})
+        .map(([key, value]) => `${key}:${value}`)
+        .join(" ");
+      return `
+        <article class="recent-run">
+          <div class="result-card-header">
+            <strong>${escapeHtml(run.runId)}</strong>
+            ${makeStatusChip(run.success ? "succeeded" : "warning")}
+          </div>
+          <p>${escapeHtml(run.request || "No request captured.")}</p>
+          <small>${escapeHtml(counts || "no status data")}</small>
+          <div class="task-controls">
+            <button class="ghost-button" type="button" data-run-id="${escapeHtml(run.runId)}">Load summary</button>
+            <button class="ghost-button" type="button" data-cleanup-run-id="${escapeHtml(run.runId)}">Cleanup</button>
+          </div>
+        </article>
+      `;
+    })
+    .join("");
+
+  elements.recentRuns.querySelectorAll("button[data-run-id]").forEach((button) => {
+    button.addEventListener("click", () => {
+      loadHistory(button.getAttribute("data-run-id"));
+    });
+  });
+  elements.recentRuns.querySelectorAll("button[data-cleanup-run-id]").forEach((button) => {
+    button.addEventListener("click", () => {
+      cleanupRun(button.getAttribute("data-cleanup-run-id")).catch((error) => {
+        elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+      });
+    });
+  });
+}
+
+function clearArtifactBrowser() {
+  state.currentHistory = null;
+  elements.cleanupCurrentRun.disabled = true;
+  elements.artifactContext.textContent = "Load a run to browse prompts, logs, and results.";
+  elements.artifactList.innerHTML = `<div class="empty-state">No run artifacts loaded yet.</div>`;
+  elements.artifactViewer.innerHTML = `<div class="empty-state">Pick a file from the run to preview it here.</div>`;
+}
+
+function renderArtifactBrowser(historyPayload) {
+  state.currentHistory = historyPayload;
+  elements.cleanupCurrentRun.disabled = false;
+  const files = historyPayload.files || [];
+  elements.artifactContext.textContent = `${historyPayload.runId} · ${historyPayload.artifactsDir || "artifact dir unknown"}`;
+  if (!files.length) {
+    elements.artifactList.innerHTML = `<div class="empty-state">This run has no recorded artifact files.</div>`;
+    elements.artifactViewer.innerHTML = `<div class="empty-state">No artifact file available to preview.</div>`;
+    return;
+  }
+
+  elements.artifactList.innerHTML = `
+    <div class="artifact-grid">
+      ${files
+        .map(
+          (file) => `
+            <article class="artifact-row">
+              <div class="artifact-meta">
+                <strong>${escapeHtml(file.kind || "file")}</strong>
+                <code>${escapeHtml(file.path)}</code>
+                <small>${escapeHtml(String(file.size || 0))} bytes</small>
+              </div>
+              <button class="ghost-button" type="button" data-artifact-path="${escapeHtml(file.path)}">Open</button>
+            </article>
+          `,
+        )
+        .join("")}
+    </div>
+  `;
+  elements.artifactList.querySelectorAll("button[data-artifact-path]").forEach((button) => {
+    button.addEventListener("click", () => {
+      loadArtifactFile(button.getAttribute("data-artifact-path"));
+    });
+  });
+}
+
+function renderArtifactFile(filePayload) {
+  elements.artifactViewer.innerHTML = `
+    <article class="result-card">
+      <div class="result-card-header">
+        <strong>${escapeHtml(filePayload.path)}</strong>
+        ${makeStatusChip(filePayload.truncated ? "warning" : "passed")}
+      </div>
+      <div class="meta-list">
+        <div><dt>Size</dt><dd>${escapeHtml(String(filePayload.size || 0))} bytes</dd></div>
+        <div><dt>Encoding</dt><dd>${escapeHtml(filePayload.encoding || "utf-8")}</dd></div>
+      </div>
+      <pre>${escapeHtml(filePayload.content || "")}</pre>
+    </article>
+  `;
+}
+
+function renderHealthSnapshot(payload) {
+  state.healthSnapshot = payload;
+  renderHeroStatus();
+  renderReadinessGate();
+  const channels = payload.channels || [];
+  const gateway = payload.gateway || {};
+  const memory = payload.memory || {};
+  elements.healthPanel.innerHTML = `
+    <div class="health-grid">
+      <article class="health-card">
+        <div class="result-card-header">
+          <h3>Core</h3>
+          ${makeStatusChip(payload.healthOk ? "passed" : "warning")}
+        </div>
+        <div class="meta-list">
+          <div><dt>Checked</dt><dd>${escapeHtml(payload.checkedAt || "")}</dd></div>
+          <div><dt>Agent</dt><dd>${escapeHtml(payload.agentId || "")}</dd></div>
+          <div><dt>Default agent</dt><dd>${escapeHtml(payload.defaultAgentId || "n/a")}</dd></div>
+          <div><dt>Target present</dt><dd>${escapeHtml(payload.targetAgentPresent ? "yes" : "no")}</dd></div>
+        </div>
+      </article>
+      <article class="health-card">
+        <div class="result-card-header">
+          <h3>Channels</h3>
+          ${makeStatusChip(channels.every((item) => item.probeOk) ? "passed" : "warning")}
+        </div>
+        <div class="meta-list">
+          ${
+            channels.length
+              ? channels
+                  .map(
+                    (channel) => `
+                      <div>
+                        <dt>${escapeHtml(channel.label || channel.name)}</dt>
+                        <dd>${escapeHtml(
+                          `${channel.configured ? "configured" : "not configured"} · ${channel.running ? "running" : "stopped"} · probe ${channel.probeOk ? "ok" : "warn"}`,
+                        )}</dd>
+                      </div>
+                    `,
+                  )
+                  .join("")
+              : `<div><dt>Channels</dt><dd>No channel data returned.</dd></div>`
+          }
+        </div>
+      </article>
+      <article class="health-card">
+        <div class="result-card-header">
+          <h3>Gateway</h3>
+          ${makeStatusChip(gateway.ok ? "passed" : "warning")}
+        </div>
+        <pre>${escapeHtml((gateway.stdout || gateway.stderr || "").trim() || "No gateway output.")}</pre>
+      </article>
+      <article class="health-card">
+        <div class="result-card-header">
+          <h3>Memory</h3>
+          ${makeStatusChip(memory.ok ? "passed" : "warning")}
+        </div>
+        <pre>${escapeHtml((memory.stdout || memory.stderr || "").trim() || "No memory output.")}</pre>
+      </article>
+    </div>
+  `;
+}
+
+function renderBootstrap(bootstrap) {
+  state.bootstrap = bootstrap;
+  elements.repoPath.value = bootstrap.repoPath || "";
+  elements.configPath.value = bootstrap.configPath || "";
+  elements.healthAgentId.value = bootstrap.defaultOpenClawAgentId || "";
+  const runtime = (bootstrap.snapshot || {}).runtime || {};
+  setMode(Boolean(runtime.dry_run) === false);
+  renderPipelines(bootstrap);
+  renderStepGrid();
+  renderWorkspaceMetrics(bootstrap);
+  renderHeroStatus();
+  renderReadinessGate();
+  renderRecentRuns(bootstrap);
+  if (!state.currentHistory) {
+    clearArtifactBrowser();
+  }
+  updateCopyButtons();
+}
+
+function renderTask(task) {
+  elements.taskStateSlot.innerHTML = makeStatusChip(task.status || "neutral");
+  elements.cancelTask.disabled = !["queued", "running"].includes(task.status);
+  elements.taskMeta.innerHTML = `
+    <div><strong>Action:</strong> ${escapeHtml(task.action)}</div>
+    <div><strong>Task id:</strong> <code>${escapeHtml(task.id)}</code></div>
+    <div><strong>Created:</strong> <code>${escapeHtml(task.createdAt)}</code></div>
+  `;
+
+  const progress = task.progress || [];
+  if (!progress.length) {
+    elements.taskProgress.innerHTML = `<div class="empty-state">No task events yet.</div>`;
+  } else {
+    elements.taskProgress.innerHTML = progress
+      .map(
+        (event) => `
+          <article class="progress-event">
+            <time>${escapeHtml(event.at)}</time>
+            <div>${escapeHtml(event.message)}</div>
+          </article>
+        `,
+      )
+      .join("");
+  }
+
+  if (task.result) {
+    renderOutput(task.result);
+  } else if (task.error) {
+    elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(task.error)}</div>`;
+  }
+}
+
+function renderChecks(checks) {
+  return `
+    <section>
+      <h3>Checks</h3>
+      <div class="check-grid">
+        ${(checks || [])
+          .map(
+            (check) => `
+              <article class="check-row">
+                <div class="result-card-header">
+                  <strong>${escapeHtml(check.name)}</strong>
+                  ${makeStatusChip(check.status)}
+                </div>
+                <div>${escapeHtml(check.message)}</div>
+              </article>
+            `,
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderPlan(plan) {
+  return `
+    <section>
+      <h3>Plan</h3>
+      <div class="plan-grid">
+        ${(plan || [])
+          .map(
+            (step) => `
+              <article class="result-card">
+                <div class="result-card-header">
+                  <strong>${escapeHtml(step.id)}</strong>
+                  ${makeStatusChip(step.mode)}
+                </div>
+                <p>${escapeHtml(step.title)}</p>
+                <dl class="meta-list">
+                  <div><dt>Agent</dt><dd>${escapeHtml(step.agent || "n/a")}</dd></div>
+                  <div><dt>Profile</dt><dd>${escapeHtml(step.profile || "n/a")}</dd></div>
+                  <div><dt>Assignment</dt><dd>${escapeHtml(step.assignment || "n/a")}</dd></div>
+                  <div><dt>Managed</dt><dd>${escapeHtml(step.managedAgent || "n/a")}</dd></div>
+                  <div><dt>Depends</dt><dd>${escapeHtml((step.dependsOn || []).join(", ") || "none")}</dd></div>
+                </dl>
+              </article>
+            `,
+          )
+          .join("")}
+      </div>
+    </section>
+  `;
+}
+
+function renderRunResults(runResult) {
+  const results = runResult.results || [];
+  const visibleResults = filterResults(results);
+  const counts = statusCounts(results);
+  const resultMarkup = visibleResults.length
+    ? visibleResults
+        .map((item) => {
+          const command = Array.isArray(item.command) ? item.command.join(" ") : "";
+          const stdout = item.stdout || "";
+          const stderr = item.stderr || "";
+          const artifacts = item.artifacts || {};
+          const metaRows = [
+            ["Profile", item.profile],
+            ["Agent", item.agent],
+            ["Mode", item.mode],
+            ["Workspace", artifacts.workspace_path || ""],
+            ["Branch", artifacts.source_branch || artifacts.branch_name || ""],
+            ["Managed agent", artifacts.managed_agent || ""],
+            ["Blocked reason", artifacts.blocked_reason || ""],
+          ].filter(([, value]) => value);
+          return `
+            <article class="result-card">
+              <div class="result-card-header">
+                <strong>${escapeHtml(item.work_item_id)}</strong>
+                ${makeStatusChip(item.status)}
+              </div>
+              <p>${escapeHtml(item.summary || "")}</p>
+              <dl class="meta-list">
+                ${metaRows
+                  .map(
+                    ([label, value]) =>
+                      `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`,
+                  )
+                  .join("")}
+              </dl>
+              ${
+                command
+                  ? `<details><summary>Command</summary><pre>${escapeHtml(command)}</pre></details>`
+                  : ""
+              }
+              ${
+                stdout
+                  ? `<details><summary>Stdout</summary><pre>${escapeHtml(stdout)}</pre></details>`
+                  : ""
+              }
+              ${
+                stderr
+                  ? `<details><summary>Stderr</summary><pre>${escapeHtml(stderr)}</pre></details>`
+                  : ""
+              }
+            </article>
+          `;
+        })
+        .join("")
+    : `<div class="empty-state">No results match the current filter.</div>`;
+  return `
+    <section>
+      <h3>Run Summary</h3>
+      <div class="result-card">
+        <div class="result-card-header">
+          <strong>${escapeHtml(runResult.run_id || "run")}</strong>
+          ${makeStatusChip(runResult.success ? "succeeded" : "warning")}
+        </div>
+        <dl class="meta-list">
+          <div><dt>Artifacts</dt><dd>${escapeHtml(runResult.artifacts_dir || "n/a")}</dd></div>
+          <div><dt>Plan steps</dt><dd>${escapeHtml(String((runResult.plan || []).length))}</dd></div>
+          <div><dt>Results</dt><dd>${escapeHtml(String(results.length))}</dd></div>
+          <div><dt>Status counts</dt><dd>${escapeHtml(formatCounts(counts))}</dd></div>
+          <div><dt>Visible filter</dt><dd>${escapeHtml(state.resultFilter)}</dd></div>
+        </dl>
+      </div>
+      <div class="result-grid">${resultMarkup}</div>
+    </section>
+  `;
+}
+
+function updateCopyButtons() {
+  const runPayload = extractRunPayload(state.currentOutput);
+  const enabled = Boolean(runPayload?.runResult);
+  elements.copyRunSummary.disabled = !enabled;
+  elements.copyIssueUpdate.disabled = !enabled;
+  elements.copyPrNote.disabled = !enabled;
+}
+
+function generateRunSummaryText() {
+  const runPayload = extractRunPayload(state.currentOutput);
+  if (!runPayload) {
+    return "";
+  }
+  const runResult = runPayload.runResult;
+  const results = runResult.results || [];
+  const counts = formatCounts(statusCounts(results));
+  const actionable = actionableResults(results);
+  const lines = [
+    `Run ID: ${runResult.run_id || "n/a"}`,
+    `Pipeline: ${runPayload.pipeline || "n/a"}`,
+    `Request: ${runPayload.request || "n/a"}`,
+    `Success: ${runResult.success ? "yes" : "no"}`,
+    `Artifacts: ${runResult.artifacts_dir || "n/a"}`,
+    `Status counts: ${counts}`,
+  ];
+  if (actionable.length) {
+    lines.push("", "Actionable results:");
+    for (const item of actionable) {
+      lines.push(`- ${item.work_item_id}: [${item.status}] ${item.summary}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+function generateIssueUpdateText() {
+  const runPayload = extractRunPayload(state.currentOutput);
+  if (!runPayload) {
+    return "";
+  }
+  const runResult = runPayload.runResult;
+  const results = runResult.results || [];
+  const actionable = actionableResults(results);
+  const lines = [
+    "OpenClaw progress update",
+    "",
+    `- Run: ${runResult.run_id || "n/a"}`,
+    `- Pipeline: ${runPayload.pipeline || "n/a"}`,
+    `- Request: ${runPayload.request || "n/a"}`,
+    `- Success: ${runResult.success ? "yes" : "no"}`,
+    `- Status counts: ${formatCounts(statusCounts(results))}`,
+  ];
+  if (actionable.length) {
+    lines.push("- Actionable items:");
+    for (const item of actionable) {
+      lines.push(`  - ${item.work_item_id}: [${item.status}] ${item.summary}`);
+    }
+  } else {
+    lines.push("- Actionable items: none");
+  }
+  return lines.join("\n");
+}
+
+function generatePrNoteText() {
+  const runPayload = extractRunPayload(state.currentOutput);
+  if (!runPayload) {
+    return "";
+  }
+  const runResult = runPayload.runResult;
+  const branch = primaryBranch(runResult);
+  const readiness = readinessFacts()
+    .map((fact) => `${fact.label}:${fact.value}`)
+    .join(" · ");
+  const lines = [
+    "PR-ready note",
+    "",
+    `Run: ${runResult.run_id || "n/a"}`,
+    `Pipeline: ${runPayload.pipeline || "n/a"}`,
+    `Request: ${runPayload.request || "n/a"}`,
+    `Branch: ${branch || "n/a"}`,
+    `Readiness: ${readiness}`,
+    `Status counts: ${formatCounts(statusCounts(runResult.results || []))}`,
+  ];
+  return lines.join("\n");
+}
+
+function renderOutput(payload) {
+  state.currentOutput = payload;
+  updateCopyButtons();
+  const chunks = [];
+  if (payload.mode === "doctor") {
+    chunks.push(renderChecks(payload.checks || []));
+  }
+  if (payload.plan) {
+    chunks.push(renderPlan(payload.plan));
+  }
+  if (payload.preflight && payload.preflight.checks) {
+    chunks.push(renderChecks(payload.preflight.checks));
+  }
+  if (payload.runResult) {
+    chunks.push(renderRunResults(payload.runResult));
+  }
+  if (payload.summary) {
+    chunks.push(renderRunResults(payload.summary));
+  }
+  elements.outputPane.innerHTML = chunks.join("") || `<div class="empty-state">No output captured.</div>`;
+  if (payload.history) {
+    renderArtifactBrowser(payload.history);
+  } else if (payload.summary && payload.files) {
+    renderArtifactBrowser(payload);
+  } else {
+    clearArtifactBrowser();
+  }
+  renderReadinessGate();
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, {
+    headers: { "Content-Type": "application/json" },
+    ...options,
+  });
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+async function loadBootstrap() {
+  const query = new URLSearchParams({
+    repoPath: elements.repoPath.value || "",
+    configPath: elements.configPath.value || "",
+    pipeline: elements.pipeline.value || "",
+  });
+  const payload = await fetchJson(`/api/bootstrap?${query.toString()}`);
+  renderBootstrap(payload);
+  setCopyFeedback("Plan, preflight, run summary, and step results.");
+}
+
+async function loadHistory(runId) {
+  const query = new URLSearchParams({
+    repoPath: elements.repoPath.value || "",
+    configPath: elements.configPath.value || "",
+  });
+  const payload = await fetchJson(`/api/history/${encodeURIComponent(runId)}?${query.toString()}`);
+  renderOutput(payload);
+}
+
+async function loadArtifactFile(relativePath) {
+  if (!state.currentHistory) {
+    return;
+  }
+  elements.artifactViewer.innerHTML = `<div class="empty-state">Loading ${escapeHtml(relativePath)}...</div>`;
+  const query = new URLSearchParams({
+    repoPath: elements.repoPath.value || "",
+    configPath: elements.configPath.value || "",
+    path: relativePath,
+  });
+  const payload = await fetchJson(
+    `/api/history/${encodeURIComponent(state.currentHistory.runId)}/file?${query.toString()}`,
+  );
+  renderArtifactFile(payload);
+}
+
+async function loadHealth() {
+  elements.healthPanel.innerHTML = `<div class="empty-state">Checking OpenClaw health...</div>`;
+  const query = new URLSearchParams({
+    repoPath: elements.repoPath.value || "",
+    configPath: elements.configPath.value || "",
+    agentId: elements.healthAgentId.value || "",
+  });
+  const payload = await fetchJson(`/api/system/health?${query.toString()}`);
+  renderHealthSnapshot(payload);
+}
+
+async function cleanupRun(runId) {
+  const confirmed = window.confirm(`Cleanup run ${runId}? This removes its artifact folder and any retained orchestration worktrees.`);
+  if (!confirmed) {
+    return;
+  }
+  elements.housekeepingStatus.textContent = `Cleaning up ${runId}...`;
+  const query = new URLSearchParams({
+    repoPath: elements.repoPath.value || "",
+    configPath: elements.configPath.value || "",
+  });
+  const payload = await fetchJson(`/api/history/${encodeURIComponent(runId)}/cleanup?${query.toString()}`, {
+    method: "POST",
+    body: JSON.stringify({
+      removeWorktrees: true,
+      removeArtifacts: true,
+    }),
+  });
+  elements.housekeepingStatus.textContent = `Cleaned ${runId}. Operations: ${(payload.operations || []).length}.`;
+  if (state.currentHistory && state.currentHistory.runId === runId) {
+    clearArtifactBrowser();
+    elements.outputPane.innerHTML = `<div class="empty-state">Run ${escapeHtml(runId)} was cleaned up.</div>`;
+  }
+  await loadBootstrap();
+}
+
+async function pruneRuns() {
+  const keepLatest = Number(elements.pruneKeepLatest.value || "10");
+  const confirmed = window.confirm(`Prune old runs and keep the latest ${keepLatest}?`);
+  if (!confirmed) {
+    return;
+  }
+  elements.housekeepingStatus.textContent = `Pruning runs, keeping latest ${keepLatest}...`;
+  const query = new URLSearchParams({
+    repoPath: elements.repoPath.value || "",
+    configPath: elements.configPath.value || "",
+  });
+  const payload = await fetchJson(`/api/history/prune?${query.toString()}`, {
+    method: "POST",
+    body: JSON.stringify({
+      keepLatest,
+      removeWorktrees: true,
+      removeArtifacts: true,
+    }),
+  });
+  elements.housekeepingStatus.textContent = `Pruned ${payload.removed.length} runs.`;
+  if (state.currentHistory && (payload.removed || []).some((item) => item.runId === state.currentHistory.runId)) {
+    clearArtifactBrowser();
+  }
+  await loadBootstrap();
+}
+
+function taskPayload(action) {
+  return {
+    action,
+    repoPath: elements.repoPath.value,
+    configPath: elements.configPath.value,
+    pipeline: elements.pipeline.value,
+    request: elements.request.value,
+    steps: selectedSteps(),
+    live: state.live,
+  };
+}
+
+async function submitTask(action) {
+  const payload = taskPayload(action);
+  const response = await fetchJson("/api/tasks", {
+    method: "POST",
+    body: JSON.stringify(payload),
+  });
+  const task = response.task;
+  state.currentTaskId = task.id;
+  renderTask(task);
+  openTaskStream(task.id);
+}
+
+function closeTaskStream() {
+  if (state.taskStream) {
+    state.taskStream.close();
+    state.taskStream = null;
+  }
+}
+
+function openTaskStream(taskId) {
+  closeTaskStream();
+  const stream = new EventSource(`/api/tasks/${encodeURIComponent(taskId)}/events`);
+  state.taskStream = stream;
+  stream.addEventListener("task", (event) => {
+    const payload = JSON.parse(event.data);
+    const task = payload.task;
+    renderTask(task);
+    if (["completed", "failed", "cancelled"].includes(task.status)) {
+      closeTaskStream();
+      loadBootstrap().catch((error) => {
+        elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+      });
+    }
+  });
+  stream.onerror = () => {
+    closeTaskStream();
+    fetchJson(`/api/tasks/${encodeURIComponent(taskId)}`)
+      .then((payload) => {
+        renderTask(payload.task);
+        if (["completed", "failed", "cancelled"].includes(payload.task.status)) {
+          return loadBootstrap();
+        }
+        elements.outputPane.innerHTML = `<div class="empty-state">Live stream disconnected. Refresh or relaunch the task feed.</div>`;
+      })
+      .catch((error) => {
+        elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+      });
+  };
+}
+
+async function cancelCurrentTask() {
+  if (!state.currentTaskId) {
+    return;
+  }
+  const payload = await fetchJson(`/api/tasks/${encodeURIComponent(state.currentTaskId)}/cancel`, {
+    method: "POST",
+  });
+  renderTask(payload.task);
+}
+
+function bindEvents() {
+  elements.refreshBootstrap.addEventListener("click", () => {
+    loadBootstrap()
+      .then(() => loadHealth())
+      .catch((error) => {
+        elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+      });
+  });
+
+  elements.pipeline.addEventListener("change", () => {
+    loadBootstrap()
+      .then(() => loadHealth())
+      .catch((error) => {
+        elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+      });
+  });
+
+  elements.resultFilter.addEventListener("change", () => {
+    state.resultFilter = elements.resultFilter.value;
+    if (state.currentOutput) {
+      renderOutput(state.currentOutput);
+    }
+    renderReadinessGate();
+  });
+
+  elements.checkHealth.addEventListener("click", () => {
+    loadHealth().catch((error) => {
+      elements.healthPanel.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+    });
+  });
+
+  elements.healthAgentId.addEventListener("input", () => {
+    renderHeroStatus();
+    renderReadinessGate();
+  });
+
+  elements.pruneRuns.addEventListener("click", () => {
+    pruneRuns().catch((error) => {
+      elements.housekeepingStatus.textContent = error.message;
+    });
+  });
+
+  elements.cancelTask.addEventListener("click", () => {
+    cancelCurrentTask().catch((error) => {
+      elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+    });
+  });
+
+  elements.cleanupCurrentRun.addEventListener("click", () => {
+    if (!state.currentHistory) {
+      return;
+    }
+    cleanupRun(state.currentHistory.runId).catch((error) => {
+      elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+    });
+  });
+
+  elements.copyRunSummary.addEventListener("click", () => {
+    copyText(generateRunSummaryText(), "Copied run summary.").catch((error) => {
+      setCopyFeedback(error.message);
+    });
+  });
+
+  elements.copyIssueUpdate.addEventListener("click", () => {
+    copyText(generateIssueUpdateText(), "Copied issue update.").catch((error) => {
+      setCopyFeedback(error.message);
+    });
+  });
+
+  elements.copyPrNote.addEventListener("click", () => {
+    copyText(generatePrNoteText(), "Copied PR note.").catch((error) => {
+      setCopyFeedback(error.message);
+    });
+  });
+
+  elements.modeToggle.addEventListener("click", () => {
+    setMode(!state.live);
+  });
+
+  elements.request.addEventListener("input", () => {
+    renderReadinessGate();
+  });
+
+  elements.selectAll.addEventListener("click", () => {
+    elements.stepGrid.querySelectorAll("input[type=checkbox]").forEach((input) => {
+      input.checked = true;
+    });
+    renderHeroStatus();
+    renderReadinessGate();
+  });
+
+  elements.selectNone.addEventListener("click", () => {
+    elements.stepGrid.querySelectorAll("input[type=checkbox]").forEach((input) => {
+      input.checked = false;
+    });
+    renderHeroStatus();
+    renderReadinessGate();
+  });
+
+  elements.buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      submitTask(button.dataset.action).catch((error) => {
+        elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+      });
+    });
+  });
+}
+
+async function boot() {
+  bindEvents();
+  await loadBootstrap();
+  await loadHealth().catch((error) => {
+    setCopyFeedback(`Health check skipped: ${error.message}`);
+  });
+  elements.cancelTask.disabled = true;
+  elements.cleanupCurrentRun.disabled = true;
+  updateCopyButtons();
+}
+
+boot().catch((error) => {
+  elements.outputPane.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
+});

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -6,6 +6,7 @@ const state = {
   currentHistory: null,
   healthSnapshot: null,
   currentOutput: null,
+  currentTaskStatus: "idle",
   resultFilter: "all",
 };
 
@@ -15,10 +16,13 @@ const elements = {
   pipeline: document.getElementById("pipeline"),
   request: document.getElementById("request"),
   stepGrid: document.getElementById("step-grid"),
+  requestPresets: document.getElementById("request-presets"),
   refreshBootstrap: document.getElementById("refresh-bootstrap"),
   modeToggle: document.getElementById("mode-toggle"),
   workspaceMetrics: document.getElementById("workspace-metrics"),
+  launchBrief: document.getElementById("launch-brief"),
   heroStatus: document.getElementById("hero-status"),
+  pipelineRadar: document.getElementById("pipeline-radar"),
   recentRuns: document.getElementById("recent-runs"),
   pruneKeepLatest: document.getElementById("prune-keep-latest"),
   pruneRuns: document.getElementById("prune-runs"),
@@ -63,8 +67,79 @@ function makeStatusChip(value) {
   return `<span class="status-chip ${normalized}">${escapeHtml(normalized)}</span>`;
 }
 
+function compactPath(value, keepSegments = 3) {
+  const text = String(value || "").trim();
+  if (!text) {
+    return "n/a";
+  }
+  const normalized = text.replaceAll("\\", "/");
+  const parts = normalized.split("/").filter(Boolean);
+  if (parts.length <= keepSegments) {
+    return normalized.startsWith("/") ? `/${parts.join("/")}` : normalized;
+  }
+  return `…/${parts.slice(-keepSegments).join("/")}`;
+}
+
+function formatAbsoluteTime(value) {
+  if (!value) {
+    return "unknown";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString([], {
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+function formatRelativeTime(value) {
+  if (!value) {
+    return "time unknown";
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  const diffMs = date.getTime() - Date.now();
+  const formatter = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const minute = 60_000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (Math.abs(diffMs) < hour) {
+    return formatter.format(Math.round(diffMs / minute), "minute");
+  }
+  if (Math.abs(diffMs) < day) {
+    return formatter.format(Math.round(diffMs / hour), "hour");
+  }
+  return formatter.format(Math.round(diffMs / day), "day");
+}
+
+function routeSequence(stepIds) {
+  return (stepIds || []).join(" → ") || "No steps selected";
+}
+
 function setCopyFeedback(message) {
   elements.copyFeedback.textContent = message;
+}
+
+function updateActionButtons() {
+  const requestReady = Boolean((elements.request.value || "").trim());
+  const taskActive = ["queued", "running"].includes(state.currentTaskStatus);
+  elements.buttons.forEach((button) => {
+    if (taskActive) {
+      button.disabled = true;
+      return;
+    }
+    if (button.dataset.action === "run") {
+      button.disabled = !requestReady;
+      return;
+    }
+    button.disabled = false;
+  });
 }
 
 function statusCounts(results) {
@@ -473,6 +548,126 @@ function renderHeroStatus() {
     .join("");
 }
 
+function renderLaunchBrief() {
+  const bootstrap = state.bootstrap || {};
+  const snapshot = bootstrap.snapshot || {};
+  const git = bootstrap.git || {};
+  const pipelineName = elements.pipeline.value || snapshot.defaultPipeline || "n/a";
+  const requestText = (elements.request.value || "").trim();
+  const effectiveIds = effectiveStepIds();
+  const explicitSelection = selectedSteps();
+  const planItems = effectivePlanItems();
+  const fallbackCount = planItems.filter((item) => item.fallbackUsed).length;
+  const owners = Array.from(
+    new Set(
+      planItems
+        .map((item) => item.managedAgent || item.assignment || item.profile || "")
+        .filter(Boolean),
+    ),
+  );
+  const usesGitHub = planItems.some((item) => String(item.mode || "").toLowerCase() === "github");
+  const tone = !requestText ? "warning" : git.dirty ? "warning" : "passed";
+  elements.launchBrief.innerHTML = `
+    <div class="brief-banner">
+      <div>
+        <span class="eyebrow">Current Vector</span>
+        <strong>${escapeHtml(pipelineName)} · ${escapeHtml(state.live ? "Live" : "Dry-run")}</strong>
+        <p>${escapeHtml(routeSequence(effectiveIds))}</p>
+      </div>
+      ${makeStatusChip(tone)}
+    </div>
+    <div class="brief-grid">
+      <article class="brief-card">
+        <span class="brief-label">Request</span>
+        <strong>${escapeHtml(requestText ? "Ready" : "Missing")}</strong>
+        <small>${escapeHtml(requestText ? `${requestText.length} chars captured` : "Add intent before launching a run.")}</small>
+      </article>
+      <article class="brief-card">
+        <span class="brief-label">Scope</span>
+        <strong>${escapeHtml(`${effectiveIds.length} effective steps`)}</strong>
+        <small>${escapeHtml(explicitSelection.length ? `${explicitSelection.length} explicitly selected` : "Full pipeline currently in play")}</small>
+      </article>
+      <article class="brief-card">
+        <span class="brief-label">Repo Base</span>
+        <strong>${escapeHtml(git.dirty ? "Dirty" : "Clean")}</strong>
+        <small>${escapeHtml(git.branch || "branch unknown")}</small>
+      </article>
+      <article class="brief-card">
+        <span class="brief-label">Tail</span>
+        <strong>${escapeHtml(usesGitHub ? "GitHub armed" : "Local only")}</strong>
+        <small>${escapeHtml(fallbackCount ? `${fallbackCount} fallback routes active` : "Assignments are explicit")}</small>
+      </article>
+    </div>
+    <div class="brief-note">
+      <strong>Execution owners</strong>
+      <span>${escapeHtml(owners.join(" · ") || "No managed agents resolved yet")}</span>
+    </div>
+  `;
+}
+
+function renderPipelineRadar() {
+  const steps = currentPipelineSteps();
+  if (!steps.length) {
+    elements.pipelineRadar.innerHTML = `<div class="empty-state">No steps are defined for the selected pipeline.</div>`;
+    return;
+  }
+
+  const effectiveSet = new Set(effectiveStepIds());
+  const explicitSet = new Set(selectedSteps());
+  const planMap = currentPlanMap();
+  const activeCount = Array.from(effectiveSet).length;
+  elements.pipelineRadar.innerHTML = `
+    <div class="radar-summary">
+      <div>
+        <strong>Effective route</strong>
+        <p>${escapeHtml(routeSequence(Array.from(effectiveSet)))}</p>
+      </div>
+      <small>${escapeHtml(`${activeCount} active · ${steps.length - activeCount} parked`)}</small>
+    </div>
+    <div class="radar-strip">
+      ${steps
+        .map((step, index) => {
+          const planItem = planMap.get(step.id) || {};
+          const isEffective = effectiveSet.has(step.id);
+          const isSelected = explicitSet.has(step.id);
+          const badges = [];
+          if (isSelected) {
+            badges.push('<span class="route-badge tone-accent">selected</span>');
+          } else if (isEffective) {
+            badges.push('<span class="route-badge tone-teal">dependency</span>');
+          } else {
+            badges.push('<span class="route-badge tone-muted">parked</span>');
+          }
+          if (planItem.fallbackUsed) {
+            badges.push('<span class="route-badge tone-gold">fallback</span>');
+          }
+          const mode = String(planItem.mode || "").toLowerCase();
+          if (mode === "github") {
+            badges.push('<span class="route-badge tone-ink">github</span>');
+          } else if (mode === "openclaw" || mode === "hermes") {
+            badges.push(`<span class="route-badge tone-teal">${escapeHtml(mode)}</span>`);
+          }
+          const routeOwner = planItem.managedAgent || step.assignment || step.profile || "n/a";
+          const depends = (step.dependsOn || []).join(", ") || "none";
+          return `
+            <article class="route-node ${isEffective ? "effective" : "inactive"}">
+              <div class="route-node-top">
+                <span class="route-index">${escapeHtml(String(index + 1))}</span>
+                <div class="route-badges">${badges.join("")}</div>
+              </div>
+              <strong>${escapeHtml(step.id)}</strong>
+              <p>${escapeHtml(step.title)}</p>
+              <small>Route: ${escapeHtml(routeOwner)}</small>
+              <small>Depends on: ${escapeHtml(depends)}</small>
+            </article>
+            ${index < steps.length - 1 ? '<div class="route-link" aria-hidden="true">→</div>' : ""}
+          `;
+        })
+        .join("")}
+    </div>
+  `;
+}
+
 async function copyText(text, successMessage) {
   if (!text) {
     return;
@@ -496,6 +691,7 @@ function setMode(live) {
   elements.modeToggle.setAttribute("aria-pressed", state.live ? "true" : "false");
   const copy = elements.modeToggle.querySelector(".toggle-copy");
   copy.textContent = state.live ? "Live" : "Dry-run";
+  renderLaunchBrief();
   renderHeroStatus();
   renderReadinessGate();
 }
@@ -510,20 +706,57 @@ function renderWorkspaceMetrics(bootstrap) {
   const git = bootstrap.git || {};
   const snapshot = bootstrap.snapshot || {};
   const runtime = snapshot.runtime || {};
-  const metrics = [
-    ["Repo", bootstrap.repoPath],
-    ["Config", bootstrap.configPath],
-    ["Branch", git.branch || "unknown"],
-    ["Dirty", git.dirty ? "yes" : "no"],
-    ["Default pipeline", snapshot.defaultPipeline || "n/a"],
-    ["Artifacts", bootstrap.artifactsRoot || "n/a"],
-    ["Live policy", runtime.allow_fallback_in_live ? "fallback allowed" : "strict"],
-    ["Live steps", Array.isArray(runtime.allowed_live_steps) ? runtime.allowed_live_steps.join(", ") : "n/a"],
+  const statCards = [
+    {
+      label: "Branch",
+      value: git.branch || "unknown",
+      detail: git.dirty ? "dirty working tree" : "clean working tree",
+    },
+    {
+      label: "Pipeline",
+      value: snapshot.defaultPipeline || "n/a",
+      detail: `${Object.keys(snapshot.pipelines || {}).length} loaded`,
+    },
+    {
+      label: "Live policy",
+      value: runtime.allow_fallback_in_live ? "relaxed" : "strict",
+      detail: runtime.require_step_selection_for_live ? "explicit steps" : "free selection",
+    },
+    {
+      label: "Live allow-list",
+      value: Array.isArray(runtime.allowed_live_steps) && runtime.allowed_live_steps.length
+        ? `${runtime.allowed_live_steps.length} steps`
+        : "n/a",
+      detail: Array.isArray(runtime.allowed_live_steps) && runtime.allowed_live_steps.length
+        ? compactPath(runtime.allowed_live_steps.join(" · "), 4)
+        : "No allow-list configured",
+    },
   ];
-  elements.workspaceMetrics.innerHTML = metrics
+  const pathCards = [
+    ["Repo root", bootstrap.repoPath],
+    ["Config", bootstrap.configPath],
+    ["Artifacts", bootstrap.artifactsRoot],
+  ];
+  elements.workspaceMetrics.innerHTML = statCards
     .map(
-      ([label, value]) =>
-        `<div><dt>${escapeHtml(label)}</dt><dd>${escapeHtml(value)}</dd></div>`,
+      (metric) => `
+        <div class="metric-card">
+          <dt>${escapeHtml(metric.label)}</dt>
+          <dd>${escapeHtml(metric.value)}</dd>
+          <small>${escapeHtml(metric.detail)}</small>
+        </div>
+      `,
+    )
+    .concat(
+      pathCards.map(
+        ([label, value]) => `
+          <div class="metric-card full" title="${escapeHtml(value || "n/a")}">
+            <dt>${escapeHtml(label)}</dt>
+            <dd>${escapeHtml(compactPath(value || "", 4))}</dd>
+            <small>${escapeHtml(value || "n/a")}</small>
+          </div>
+        `,
+      ),
     )
     .join("");
 }
@@ -576,8 +809,60 @@ function renderStepGrid() {
 
   elements.stepGrid.querySelectorAll("input[type=checkbox]").forEach((input) => {
     input.addEventListener("change", () => {
+      renderLaunchBrief();
+      renderPipelineRadar();
       renderHeroStatus();
       renderReadinessGate();
+    });
+  });
+}
+
+function renderRequestPresets() {
+  const pipelineName = elements.pipeline.value || state.bootstrap?.snapshot?.defaultPipeline || "selected pipeline";
+  const presets = [
+    {
+      label: "Doc update",
+      text: `Update the README and config notes for ${pipelineName}, then summarize any risks before implementation.`,
+    },
+    {
+      label: "Runtime bug",
+      text: `Investigate a runtime failure in ${pipelineName}, fix the root cause, and capture validation steps for review.`,
+    },
+    {
+      label: "Preflight audit",
+      text: `Audit ${pipelineName} for blockers, assignment mismatches, and live-mode risks before changing code.`,
+    },
+    {
+      label: "GitHub follow-up",
+      text: `Run the selected ${pipelineName} steps and prepare the issue / PR follow-up with a concise collaboration summary.`,
+    },
+  ];
+  elements.requestPresets.innerHTML = presets
+    .map(
+      (preset) => `
+        <button
+          class="preset-chip"
+          type="button"
+          data-request-preset="${escapeHtml(preset.text)}"
+        >
+          ${escapeHtml(preset.label)}
+        </button>
+      `,
+    )
+    .join("");
+  elements.requestPresets.querySelectorAll("button[data-request-preset]").forEach((button) => {
+    button.addEventListener("click", () => {
+      const nextValue = button.getAttribute("data-request-preset") || "";
+      if (elements.request.value.trim() && elements.request.value.trim() !== nextValue) {
+        const confirmed = window.confirm("Replace the current request text with this starter?");
+        if (!confirmed) {
+          return;
+        }
+      }
+      elements.request.value = nextValue;
+      renderLaunchBrief();
+      renderReadinessGate();
+      elements.request.focus();
     });
   });
 }
@@ -600,7 +885,12 @@ function renderRecentRuns(bootstrap) {
             ${makeStatusChip(run.success ? "succeeded" : "warning")}
           </div>
           <p>${escapeHtml(run.request || "No request captured.")}</p>
-          <small>${escapeHtml(counts || "no status data")}</small>
+          <div class="recent-run-meta">
+            <span>${escapeHtml(formatRelativeTime(run.updatedAt))}</span>
+            <span>${escapeHtml(`${run.stepCount || 0} planned steps`)}</span>
+            <span>${escapeHtml(counts || "no status data")}</span>
+          </div>
+          <small>${escapeHtml(formatAbsoluteTime(run.updatedAt))}</small>
           <div class="task-controls">
             <button class="ghost-button" type="button" data-run-id="${escapeHtml(run.runId)}">Load summary</button>
             <button class="ghost-button" type="button" data-cleanup-run-id="${escapeHtml(run.runId)}">Cleanup</button>
@@ -756,17 +1046,23 @@ function renderBootstrap(bootstrap) {
   setMode(Boolean(runtime.dry_run) === false);
   renderPipelines(bootstrap);
   renderStepGrid();
+  renderRequestPresets();
   renderWorkspaceMetrics(bootstrap);
+  renderLaunchBrief();
   renderHeroStatus();
+  renderPipelineRadar();
   renderReadinessGate();
   renderRecentRuns(bootstrap);
   if (!state.currentHistory) {
     clearArtifactBrowser();
   }
+  updateActionButtons();
   updateCopyButtons();
 }
 
 function renderTask(task) {
+  state.currentTaskStatus = task.status || "idle";
+  updateActionButtons();
   elements.taskStateSlot.innerHTML = makeStatusChip(task.status || "neutral");
   elements.cancelTask.disabled = !["queued", "running"].includes(task.status);
   elements.taskMeta.innerHTML = `
@@ -1304,13 +1600,17 @@ function bindEvents() {
   });
 
   elements.request.addEventListener("input", () => {
+    renderLaunchBrief();
     renderReadinessGate();
+    updateActionButtons();
   });
 
   elements.selectAll.addEventListener("click", () => {
     elements.stepGrid.querySelectorAll("input[type=checkbox]").forEach((input) => {
       input.checked = true;
     });
+    renderLaunchBrief();
+    renderPipelineRadar();
     renderHeroStatus();
     renderReadinessGate();
   });
@@ -1319,6 +1619,8 @@ function bindEvents() {
     elements.stepGrid.querySelectorAll("input[type=checkbox]").forEach((input) => {
       input.checked = false;
     });
+    renderLaunchBrief();
+    renderPipelineRadar();
     renderHeroStatus();
     renderReadinessGate();
   });
@@ -1338,8 +1640,10 @@ async function boot() {
   await loadHealth().catch((error) => {
     setCopyFeedback(`Health check skipped: ${error.message}`);
   });
+  state.currentTaskStatus = "idle";
   elements.cancelTask.disabled = true;
   elements.cleanupCurrentRun.disabled = true;
+  updateActionButtons();
   updateCopyButtons();
 }
 

--- a/openclaw_v2/webui/index.html
+++ b/openclaw_v2/webui/index.html
@@ -72,7 +72,7 @@
 
       <section class="deck">
         <header class="hero panel">
-          <div>
+          <div class="hero-copy">
             <p class="eyebrow">Hybrid CLI + GitHub orchestration</p>
             <h2>Run the project like a control room, not a terminal maze.</h2>
             <p class="lede">
@@ -80,8 +80,21 @@
               the pipeline looks clean.
             </p>
           </div>
-          <div class="hero-status" id="hero-status"></div>
+          <div class="hero-board">
+            <div id="launch-brief" class="launch-brief"></div>
+            <div class="hero-status" id="hero-status"></div>
+          </div>
         </header>
+
+        <section class="panel flight-plan">
+          <div class="panel-head">
+            <h2>Pipeline Radar</h2>
+            <span class="subtle">See the effective route, dependencies, and execution owners before you launch.</span>
+          </div>
+          <div id="pipeline-radar" class="pipeline-radar">
+            <div class="empty-state">Load a pipeline to inspect the effective route.</div>
+          </div>
+        </section>
 
         <section class="panel workbench">
           <div class="panel-head">
@@ -121,6 +134,7 @@
                 rows="5"
                 placeholder="Describe the change or diagnostic you want the pipeline to run."
               ></textarea>
+              <div id="request-presets" class="preset-row"></div>
             </label>
 
             <fieldset class="field field-full">

--- a/openclaw_v2/webui/index.html
+++ b/openclaw_v2/webui/index.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenClaw Mission Control</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <div class="wash wash-a"></div>
+    <div class="wash wash-b"></div>
+    <main class="shell">
+      <aside class="rail">
+        <section class="panel brand-panel">
+          <p class="eyebrow">OpenClaw v2</p>
+          <h1>Mission Control Deck</h1>
+          <p class="lede">
+            Plan, preflight, launch, and inspect the CLI plus GitHub workflow
+            pipeline from one control surface.
+          </p>
+        </section>
+
+        <section class="panel compact-panel">
+          <div class="panel-head">
+            <h2>Workspace</h2>
+            <button id="refresh-bootstrap" class="ghost-button" type="button">
+              Refresh
+            </button>
+          </div>
+          <dl class="metric-grid" id="workspace-metrics"></dl>
+        </section>
+
+        <section class="panel compact-panel">
+          <div class="panel-head">
+            <h2>OpenClaw Health</h2>
+            <button id="check-health" class="ghost-button" type="button">
+              Check
+            </button>
+          </div>
+          <label class="field">
+            <span>Agent id</span>
+            <input id="health-agent-id" type="text" autocomplete="off" />
+          </label>
+          <div id="health-panel" class="stack">
+            <div class="empty-state">Health snapshot has not been loaded yet.</div>
+          </div>
+        </section>
+
+        <section class="panel compact-panel">
+          <div class="panel-head">
+            <h2>Recent Runs</h2>
+          </div>
+          <div id="recent-runs" class="stack"></div>
+        </section>
+
+        <section class="panel compact-panel">
+          <div class="panel-head">
+            <h2>Housekeeping</h2>
+          </div>
+          <label class="field">
+            <span>Keep latest runs</span>
+            <input id="prune-keep-latest" type="number" min="0" value="10" />
+          </label>
+          <button id="prune-runs" class="action-button secondary" type="button">
+            Prune old runs
+          </button>
+          <div id="housekeeping-status" class="subtle">
+            Old run folders and retained orchestration worktrees can be cleaned here.
+          </div>
+        </section>
+      </aside>
+
+      <section class="deck">
+        <header class="hero panel">
+          <div>
+            <p class="eyebrow">Hybrid CLI + GitHub orchestration</p>
+            <h2>Run the project like a control room, not a terminal maze.</h2>
+            <p class="lede">
+              Use dry-run to inspect the plan, then escalate to live mode when
+              the pipeline looks clean.
+            </p>
+          </div>
+          <div class="hero-status" id="hero-status"></div>
+        </header>
+
+        <section class="panel workbench">
+          <div class="panel-head">
+            <h2>Launch Pad</h2>
+            <span class="subtle">Explicit steps stay safer in live mode.</span>
+          </div>
+
+          <form id="control-form" class="control-form">
+            <label class="field">
+              <span>Repo path</span>
+              <input id="repo-path" name="repoPath" type="text" autocomplete="off" />
+            </label>
+
+            <label class="field">
+              <span>Config path</span>
+              <input id="config-path" name="configPath" type="text" autocomplete="off" />
+            </label>
+
+            <label class="field">
+              <span>Pipeline</span>
+              <select id="pipeline" name="pipeline"></select>
+            </label>
+
+            <label class="field toggle-field">
+              <span>Mode</span>
+              <button id="mode-toggle" type="button" class="mode-toggle" aria-pressed="false">
+                <span class="toggle-pill"></span>
+                <span class="toggle-copy">Dry-run</span>
+              </button>
+            </label>
+
+            <label class="field field-full">
+              <span>Request</span>
+              <textarea
+                id="request"
+                name="request"
+                rows="5"
+                placeholder="Describe the change or diagnostic you want the pipeline to run."
+              ></textarea>
+            </label>
+
+            <fieldset class="field field-full">
+              <div class="field-head">
+                <legend>Steps</legend>
+                <div class="step-actions">
+                  <button id="select-none" type="button" class="ghost-button">Clear</button>
+                  <button id="select-all" type="button" class="ghost-button">All</button>
+                </div>
+              </div>
+              <div id="step-grid" class="step-grid"></div>
+            </fieldset>
+
+            <div class="action-row field-full">
+              <button data-action="diagnose" class="action-button secondary" type="button">
+                Diagnose plan
+              </button>
+              <button data-action="preflight" class="action-button secondary" type="button">
+                Run preflight
+              </button>
+              <button data-action="doctor" class="action-button secondary" type="button">
+                Doctor config
+              </button>
+              <button data-action="run" class="action-button primary" type="button">
+                Launch pipeline
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <section class="panel">
+          <div class="panel-head">
+            <h2>Readiness Gate</h2>
+            <span id="readiness-state-slot"><span class="status-chip neutral">Unchecked</span></span>
+          </div>
+          <div id="readiness-summary" class="subtle">
+            The gate will evaluate your current request, steps, repo state, and health snapshot.
+          </div>
+          <div id="readiness-checks" class="check-grid">
+            <div class="empty-state">Readiness checks will appear here.</div>
+          </div>
+        </section>
+
+        <section class="results-grid">
+          <section class="panel">
+            <div class="panel-head">
+              <h2>Task Feed</h2>
+              <div class="task-controls">
+                <button id="cancel-task" class="ghost-button" type="button" disabled>
+                  Cancel
+                </button>
+                <span id="task-state-slot"><span id="task-state" class="status-chip neutral">Idle</span></span>
+              </div>
+            </div>
+            <div id="task-meta" class="task-meta"></div>
+            <div id="task-progress" class="progress-log empty-state">
+              No task running yet.
+            </div>
+          </section>
+
+          <div class="output-stack">
+            <section class="panel">
+              <div class="panel-head">
+                <h2>Output</h2>
+                <div class="task-controls output-controls">
+                  <select id="result-filter" class="compact-select">
+                    <option value="all">All results</option>
+                    <option value="actionable">Actionable only</option>
+                    <option value="failed-blocked">Failed + blocked</option>
+                    <option value="skipped">Skipped</option>
+                    <option value="succeeded">Succeeded</option>
+                  </select>
+                  <button id="copy-run-summary" class="ghost-button" type="button" disabled>
+                    Copy run summary
+                  </button>
+                  <button id="copy-issue-update" class="ghost-button" type="button" disabled>
+                    Copy issue update
+                  </button>
+                  <button id="copy-pr-note" class="ghost-button" type="button" disabled>
+                    Copy PR note
+                  </button>
+                </div>
+              </div>
+              <div id="copy-feedback" class="subtle">
+                Plan, preflight, run summary, and step results.
+              </div>
+              <div id="output-pane" class="output-pane empty-state">
+                Start with Diagnose plan or Run preflight to populate this deck.
+              </div>
+            </section>
+
+            <section class="panel">
+              <div class="panel-head">
+                <h2>Run Files</h2>
+                <div class="task-controls">
+                  <button id="cleanup-current-run" class="ghost-button" type="button" disabled>
+                    Cleanup run
+                  </button>
+                  <span id="artifact-context" class="subtle">Load a run to browse prompts, logs, and results.</span>
+                </div>
+              </div>
+              <div id="artifact-list" class="artifact-list empty-state">
+                No run artifacts loaded yet.
+              </div>
+              <div id="artifact-viewer" class="artifact-viewer empty-state">
+                Pick a file from the run to preview it here.
+              </div>
+            </section>
+          </div>
+        </section>
+      </section>
+    </main>
+
+    <template id="status-chip-template">
+      <span class="status-chip"></span>
+    </template>
+    <script src="/static/app.js" defer></script>
+  </body>
+</html>

--- a/openclaw_v2/webui/styles.css
+++ b/openclaw_v2/webui/styles.css
@@ -169,24 +169,105 @@ h3 {
 }
 
 .hero {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(300px, 0.95fr);
   gap: 18px;
-  align-items: flex-start;
+  align-items: stretch;
+}
+
+.hero-copy {
+  display: grid;
+  gap: 14px;
+  align-content: start;
+}
+
+.hero-board {
+  display: grid;
+  gap: 12px;
 }
 
 .hero-status {
   display: grid;
   gap: 10px;
-  min-width: 260px;
 }
 
 .hero-card,
-.hero-status .fact {
+.hero-status .fact,
+.launch-brief {
   padding: 14px 16px;
   border-radius: 18px;
   background: rgba(18, 32, 51, 0.06);
   border: 1px solid rgba(18, 32, 51, 0.08);
+}
+
+.launch-brief {
+  display: grid;
+  gap: 14px;
+  background:
+    linear-gradient(135deg, rgba(18, 32, 51, 0.95), rgba(32, 52, 73, 0.92)),
+    rgba(18, 32, 51, 0.08);
+  color: #f7f1e5;
+}
+
+.launch-brief .eyebrow {
+  margin-bottom: 6px;
+  color: #f6b078;
+}
+
+.brief-banner {
+  display: flex;
+  justify-content: space-between;
+  gap: 14px;
+  align-items: flex-start;
+}
+
+.brief-banner strong {
+  display: block;
+  font-size: 1.15rem;
+  line-height: 1.2;
+}
+
+.brief-banner p,
+.brief-note {
+  margin: 6px 0 0;
+  color: rgba(247, 241, 229, 0.78);
+}
+
+.brief-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.brief-card {
+  display: grid;
+  gap: 4px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.brief-label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(247, 241, 229, 0.62);
+}
+
+.brief-card strong {
+  font-size: 1rem;
+}
+
+.brief-card small,
+.brief-note span {
+  color: rgba(247, 241, 229, 0.72);
+}
+
+.brief-note strong {
+  display: block;
+  margin-bottom: 4px;
 }
 
 .hero-status .fact strong {
@@ -194,11 +275,146 @@ h3 {
   margin-bottom: 4px;
 }
 
+.flight-plan {
+  display: grid;
+  gap: 16px;
+}
+
+.pipeline-radar {
+  display: grid;
+  gap: 16px;
+}
+
+.radar-summary {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-end;
+}
+
+.radar-summary p {
+  margin: 6px 0 0;
+  color: var(--ink-soft);
+}
+
+.radar-strip {
+  display: flex;
+  gap: 12px;
+  align-items: stretch;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.route-node {
+  flex: 0 0 248px;
+  display: grid;
+  gap: 10px;
+  padding: 16px;
+  border-radius: 20px;
+  border: 1px solid rgba(18, 32, 51, 0.1);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.88), rgba(255, 250, 241, 0.92));
+}
+
+.route-node.inactive {
+  opacity: 0.58;
+  filter: saturate(0.8);
+}
+
+.route-node.effective {
+  box-shadow: 0 18px 40px rgba(18, 32, 51, 0.08);
+  border-color: rgba(20, 122, 120, 0.18);
+}
+
+.route-node p,
+.route-node small {
+  margin: 0;
+  color: var(--ink-soft);
+}
+
+.route-node-top,
+.route-badges {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.route-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 34px;
+  height: 34px;
+  border-radius: 999px;
+  background: rgba(18, 32, 51, 0.08);
+  font-family: var(--font-mono);
+  font-weight: 700;
+}
+
+.route-badge {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 5px 10px;
+  font-size: 0.74rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.tone-accent {
+  background: rgba(217, 101, 59, 0.14);
+  color: var(--accent-deep);
+}
+
+.tone-teal {
+  background: rgba(20, 122, 120, 0.14);
+  color: var(--teal);
+}
+
+.tone-gold {
+  background: rgba(196, 141, 31, 0.16);
+  color: var(--gold);
+}
+
+.tone-ink {
+  background: rgba(18, 32, 51, 0.1);
+  color: var(--ink);
+}
+
+.tone-muted {
+  background: rgba(68, 82, 102, 0.12);
+  color: var(--ink-soft);
+}
+
+.route-link {
+  display: flex;
+  align-items: center;
+  color: rgba(18, 32, 51, 0.28);
+  font-size: 1.4rem;
+  padding: 0 2px;
+}
+
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
   margin: 0;
+}
+
+.metric-card {
+  display: grid;
+  gap: 6px;
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(18, 32, 51, 0.05);
+  border: 1px solid rgba(18, 32, 51, 0.08);
+}
+
+.metric-card.full {
+  grid-column: 1 / -1;
 }
 
 .metric-grid dt {
@@ -213,6 +429,12 @@ h3 {
   margin: 0;
   font-family: var(--font-mono);
   font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.metric-grid small {
+  color: var(--ink-soft);
+  line-height: 1.4;
   word-break: break-word;
 }
 
@@ -234,6 +456,15 @@ h3 {
   justify-self: start;
 }
 
+.recent-run-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+}
+
 .control-form {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -243,6 +474,28 @@ h3 {
 .field {
   display: grid;
   gap: 8px;
+}
+
+.preset-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.preset-chip {
+  border: 1px solid rgba(18, 32, 51, 0.1);
+  border-radius: 999px;
+  padding: 8px 12px;
+  background: rgba(18, 32, 51, 0.05);
+  color: var(--ink);
+  cursor: pointer;
+  transition: transform 120ms ease, background 120ms ease, border-color 120ms ease;
+}
+
+.preset-chip:hover {
+  transform: translateY(-1px);
+  background: rgba(217, 101, 59, 0.1);
+  border-color: rgba(217, 101, 59, 0.22);
 }
 
 .field-full {
@@ -388,6 +641,14 @@ pre {
 .action-button:hover,
 .ghost-button:hover {
   transform: translateY(-1px);
+}
+
+.action-button:disabled,
+.ghost-button:disabled,
+.preset-chip:disabled {
+  opacity: 0.48;
+  cursor: not-allowed;
+  transform: none;
 }
 
 .action-button.primary {
@@ -599,18 +860,17 @@ pre {
     grid-template-columns: 1fr;
   }
 
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
   .results-grid,
   .control-form {
     grid-template-columns: 1fr;
   }
 
-  .hero {
-    flex-direction: column;
-  }
-
   .hero-status {
-    min-width: 0;
-    width: 100%;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }
 
@@ -627,6 +887,21 @@ pre {
 
   .metric-grid {
     grid-template-columns: 1fr;
+  }
+
+  .brief-grid,
+  .hero-status {
+    grid-template-columns: 1fr;
+  }
+
+  .brief-banner,
+  .radar-summary {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .route-node {
+    flex-basis: 86vw;
   }
 
   .action-row {

--- a/openclaw_v2/webui/styles.css
+++ b/openclaw_v2/webui/styles.css
@@ -1,0 +1,641 @@
+:root {
+  --paper: #f4efe6;
+  --paper-strong: #fffaf1;
+  --ink: #122033;
+  --ink-soft: #445266;
+  --line: rgba(18, 32, 51, 0.12);
+  --accent: #d9653b;
+  --accent-deep: #b04b27;
+  --teal: #147a78;
+  --gold: #c48d1f;
+  --danger: #b63e2f;
+  --panel-shadow: 0 24px 60px rgba(18, 32, 51, 0.12);
+  --radius: 22px;
+  --radius-small: 14px;
+  --font-ui: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  --font-display: "Iowan Old Style", "Palatino Linotype", "Book Antiqua", serif;
+  --font-mono: "SFMono-Regular", Menlo, Consolas, monospace;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  min-height: 100%;
+  background:
+    radial-gradient(circle at top left, rgba(201, 141, 35, 0.12), transparent 32%),
+    radial-gradient(circle at bottom right, rgba(20, 122, 120, 0.14), transparent 28%),
+    linear-gradient(180deg, #f8f3eb 0%, #f4efe6 100%);
+  color: var(--ink);
+  font-family: var(--font-ui);
+}
+
+body {
+  position: relative;
+  overflow-x: hidden;
+}
+
+.wash {
+  position: fixed;
+  inset: auto;
+  border-radius: 999px;
+  pointer-events: none;
+  filter: blur(18px);
+  opacity: 0.35;
+}
+
+.wash-a {
+  top: -120px;
+  right: -80px;
+  width: 320px;
+  height: 320px;
+  background: rgba(217, 101, 59, 0.22);
+}
+
+.wash-b {
+  left: -110px;
+  bottom: 8%;
+  width: 260px;
+  height: 260px;
+  background: rgba(20, 122, 120, 0.22);
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  grid-template-columns: 330px minmax(0, 1fr);
+  gap: 24px;
+  padding: 24px;
+}
+
+.rail,
+.deck {
+  display: grid;
+  gap: 20px;
+  align-content: start;
+}
+
+.panel {
+  background: rgba(255, 250, 241, 0.88);
+  backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: var(--radius);
+  box-shadow: var(--panel-shadow);
+  padding: 22px;
+}
+
+.compact-panel {
+  padding-top: 18px;
+}
+
+.brand-panel {
+  background:
+    linear-gradient(145deg, rgba(18, 32, 51, 0.94), rgba(30, 44, 63, 0.92)),
+    var(--paper);
+  color: #f8f2e8;
+}
+
+.brand-panel .lede,
+.hero .lede {
+  max-width: 48ch;
+}
+
+.eyebrow {
+  margin: 0 0 10px;
+  color: var(--accent);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.brand-panel .eyebrow {
+  color: #f6b078;
+}
+
+h1,
+h2,
+h3 {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  line-height: 1.05;
+}
+
+h1 {
+  font-size: clamp(2rem, 4vw, 2.6rem);
+}
+
+h2 {
+  font-size: clamp(1.35rem, 2.6vw, 1.8rem);
+}
+
+h3 {
+  font-size: 1.05rem;
+}
+
+.lede,
+.subtle,
+.field span,
+.metric-grid dd,
+.result-card p,
+.task-meta,
+.recent-run p {
+  color: var(--ink-soft);
+}
+
+.panel-head,
+.field-head,
+.action-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.task-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.output-controls {
+  justify-content: flex-end;
+}
+
+.hero {
+  display: flex;
+  justify-content: space-between;
+  gap: 18px;
+  align-items: flex-start;
+}
+
+.hero-status {
+  display: grid;
+  gap: 10px;
+  min-width: 260px;
+}
+
+.hero-card,
+.hero-status .fact {
+  padding: 14px 16px;
+  border-radius: 18px;
+  background: rgba(18, 32, 51, 0.06);
+  border: 1px solid rgba(18, 32, 51, 0.08);
+}
+
+.hero-status .fact strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.metric-grid dt {
+  margin: 0 0 4px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.metric-grid dd {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.9rem;
+  word-break: break-word;
+}
+
+.stack {
+  display: grid;
+  gap: 12px;
+}
+
+.recent-run {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  background: rgba(18, 32, 51, 0.04);
+  border: 1px solid rgba(18, 32, 51, 0.08);
+  border-radius: 18px;
+}
+
+.recent-run button {
+  justify-self: start;
+}
+
+.control-form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.field {
+  display: grid;
+  gap: 8px;
+}
+
+.field-full {
+  grid-column: 1 / -1;
+}
+
+.field span,
+.field legend {
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+input,
+select,
+textarea,
+button {
+  font: inherit;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-small);
+  padding: 13px 14px;
+  background: rgba(255, 255, 255, 0.72);
+  color: var(--ink);
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.compact-select {
+  width: auto;
+  min-width: 150px;
+  padding: 10px 12px;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: none;
+  border-color: rgba(217, 101, 59, 0.65);
+  box-shadow: 0 0 0 4px rgba(217, 101, 59, 0.12);
+}
+
+.toggle-field {
+  align-content: end;
+}
+
+.mode-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  width: fit-content;
+  border: 0;
+  border-radius: 999px;
+  background: rgba(18, 32, 51, 0.08);
+  color: var(--ink);
+  padding: 8px 14px 8px 8px;
+  cursor: pointer;
+}
+
+.toggle-pill {
+  width: 44px;
+  height: 28px;
+  border-radius: 999px;
+  background: var(--teal);
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.28);
+}
+
+.mode-toggle[aria-pressed="true"] .toggle-pill {
+  background: var(--accent);
+}
+
+.toggle-copy {
+  font-weight: 700;
+}
+
+.step-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+}
+
+.step-card {
+  display: grid;
+  gap: 8px;
+  padding: 14px;
+  border: 1px solid rgba(18, 32, 51, 0.12);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.65);
+}
+
+.step-card label {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.step-card input {
+  width: auto;
+  margin-top: 3px;
+}
+
+.step-card strong {
+  display: block;
+  margin-bottom: 4px;
+}
+
+.step-card code,
+.task-meta code,
+.result-card code,
+.progress-event code,
+.empty-state code,
+pre {
+  font-family: var(--font-mono);
+}
+
+.action-row {
+  justify-content: flex-start;
+  flex-wrap: wrap;
+}
+
+.action-button,
+.ghost-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 11px 16px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 120ms ease, opacity 120ms ease, background 120ms ease;
+}
+
+.action-button:hover,
+.ghost-button:hover {
+  transform: translateY(-1px);
+}
+
+.action-button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+  color: #fff8f2;
+}
+
+.action-button.secondary,
+.ghost-button {
+  background: rgba(18, 32, 51, 0.08);
+  color: var(--ink);
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.9fr) minmax(0, 1.2fr);
+  gap: 20px;
+}
+
+.output-stack {
+  display: grid;
+  gap: 20px;
+}
+
+.task-meta {
+  margin: 0 0 14px;
+  font-size: 0.92rem;
+}
+
+.progress-log,
+.output-pane {
+  display: grid;
+  gap: 12px;
+  min-height: 220px;
+}
+
+.artifact-list,
+.artifact-viewer {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.artifact-grid,
+.health-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.artifact-row,
+.health-card {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(18, 32, 51, 0.05);
+  border: 1px solid rgba(18, 32, 51, 0.08);
+}
+
+.artifact-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: center;
+}
+
+.artifact-meta {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.artifact-meta code {
+  word-break: break-all;
+}
+
+.health-card h3,
+.artifact-row strong {
+  margin: 0;
+}
+
+.progress-event,
+.result-card,
+.check-row {
+  padding: 14px;
+  border-radius: 18px;
+  background: rgba(18, 32, 51, 0.05);
+  border: 1px solid rgba(18, 32, 51, 0.08);
+}
+
+.progress-event time,
+.recent-run small,
+.check-row small {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--ink-soft);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+
+.result-grid,
+.check-grid,
+.plan-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.result-card-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 10px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.result-card p {
+  margin: 8px 0 0;
+}
+
+.meta-list {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+  font-size: 0.92rem;
+}
+
+.meta-list div {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.meta-list dt {
+  font-weight: 700;
+}
+
+.meta-list dd {
+  margin: 0;
+  color: var(--ink-soft);
+  word-break: break-word;
+}
+
+details {
+  margin-top: 12px;
+}
+
+summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+pre {
+  white-space: pre-wrap;
+  word-break: break-word;
+  background: rgba(18, 32, 51, 0.07);
+  border-radius: 16px;
+  padding: 14px;
+  overflow: auto;
+}
+
+.status-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  border-radius: 999px;
+  padding: 6px 10px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-chip.neutral {
+  background: rgba(18, 32, 51, 0.08);
+  color: var(--ink);
+}
+
+.status-chip.running,
+.status-chip.succeeded,
+.status-chip.passed,
+.status-chip.completed {
+  background: rgba(20, 122, 120, 0.14);
+  color: var(--teal);
+}
+
+.status-chip.failed,
+.status-chip.blocked {
+  background: rgba(182, 62, 47, 0.12);
+  color: var(--danger);
+}
+
+.status-chip.skipped,
+.status-chip.warning,
+.status-chip.cancelled {
+  background: rgba(196, 141, 31, 0.16);
+  color: var(--gold);
+}
+
+.empty-state {
+  display: grid;
+  place-items: center;
+  border: 1px dashed rgba(18, 32, 51, 0.16);
+  border-radius: var(--radius);
+  padding: 28px;
+  text-align: center;
+  color: var(--ink-soft);
+}
+
+@media (max-width: 1120px) {
+  .shell {
+    grid-template-columns: 1fr;
+  }
+
+  .results-grid,
+  .control-form {
+    grid-template-columns: 1fr;
+  }
+
+  .hero {
+    flex-direction: column;
+  }
+
+  .hero-status {
+    min-width: 0;
+    width: 100%;
+  }
+}
+
+@media (max-width: 640px) {
+  .shell {
+    padding: 14px;
+    gap: 16px;
+  }
+
+  .panel {
+    padding: 16px;
+    border-radius: 18px;
+  }
+
+  .metric-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .action-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .action-button,
+  .ghost-button {
+    width: 100%;
+  }
+}

--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -1,8 +1,11 @@
 import io
+import os
+import sys
 import unittest
 from contextlib import redirect_stdout
+from unittest import mock
 
-from main_v2 import _print_plan_diagnostics, _print_result, _validate_live_policy
+from main_v2 import _print_plan_diagnostics, _print_result, _validate_live_policy, main
 from openclaw_v2.config import load_app_config
 from openclaw_v2.models import AgentResult, AgentType, ExecutionMode, RunResult, TaskStatus, WorkItem
 from openclaw_v2.orchestrator import HybridOrchestrator
@@ -363,6 +366,65 @@ class MainV2PolicyTests(unittest.TestCase):
 
         self.assertIn("fallback managed agents", str(error.exception))
         self.assertIn("implement -> cursor_editor", str(error.exception))
+
+
+class MainV2WebModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_main_starts_web_server_with_expected_args(self) -> None:
+        class FakeOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "main_v2.py",
+                    "--web",
+                    "--config",
+                    "config_v2.yaml",
+                    "--repo-path",
+                    ".",
+                    "--web-host",
+                    "0.0.0.0",
+                    "--web-port",
+                    "9900",
+                ],
+            ),
+            mock.patch("main_v2.HybridOrchestrator", FakeOrchestrator),
+            mock.patch("openclaw_v2.web.run_web_server", new_callable=mock.AsyncMock) as run_web_server,
+        ):
+            await main()
+
+        run_web_server.assert_awaited_once_with(
+            config_path=os.path.abspath("config_v2.yaml"),
+            repo_path=os.path.abspath("."),
+            host="0.0.0.0",
+            port=9900,
+        )
+
+    async def test_main_rejects_web_with_request(self) -> None:
+        class FakeOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "main_v2.py",
+                    "--web",
+                    "--request",
+                    "hello",
+                ],
+            ),
+            mock.patch("main_v2.HybridOrchestrator", FakeOrchestrator),
+        ):
+            with self.assertRaises(SystemExit) as error:
+                await main()
+
+        self.assertIn("--web cannot be combined", str(error.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -98,6 +98,9 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn('id="copy-run-summary"', page)
         self.assertIn('id="copy-issue-update"', page)
         self.assertIn('id="copy-pr-note"', page)
+        self.assertIn('id="launch-brief"', page)
+        self.assertIn('id="pipeline-radar"', page)
+        self.assertIn('id="request-presets"', page)
 
     async def test_health_endpoint_returns_snapshot(self) -> None:
         fake_health = {

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1,0 +1,403 @@
+import asyncio
+import json
+import os
+import tempfile
+import textwrap
+import unittest
+from unittest import mock
+
+from aiohttp.test_utils import TestClient, TestServer
+
+from openclaw_v2.models import AgentResult, AgentType, ExecutionMode, RunResult, TaskStatus, WorkItem
+from openclaw_v2.web import create_web_app
+
+
+def _write_minimal_config(path: str) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(
+            textwrap.dedent(
+                """
+                runtime:
+                  pipeline: demo_pipeline
+                  dry_run: true
+
+                profiles:
+                  codex_local:
+                    agent: codex
+                    mode: cli
+                    command:
+                      - echo
+                      - "{prompt}"
+
+                managed_agents:
+                  codex_builder:
+                    kind: codex
+                    profile: codex_local
+                    capabilities:
+                      - implement
+
+                assignments:
+                  implement_local:
+                    agent: codex_builder
+                    required_capabilities:
+                      - implement
+
+                pipelines:
+                  demo_pipeline:
+                    - id: implement
+                      title: Implement docs
+                      assignment: implement_local
+                      prompt_template: |
+                        Implement request:
+                        {user_request}
+                """
+            ).strip()
+        )
+        handle.write("\n")
+
+
+class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_path = self.temp_dir.name
+        self.config_path = os.path.join(self.repo_path, "config_v2.yaml")
+        _write_minimal_config(self.config_path)
+        self.client = TestClient(
+            TestServer(
+                create_web_app(
+                    config_path=self.config_path,
+                    repo_path=self.repo_path,
+                )
+            )
+        )
+        await self.client.start_server()
+
+    async def asyncTearDown(self) -> None:
+        await self.client.close()
+        self.temp_dir.cleanup()
+
+    async def test_bootstrap_returns_pipeline_snapshot(self) -> None:
+        response = await self.client.get("/api/bootstrap")
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+
+        self.assertEqual(payload["snapshot"]["defaultPipeline"], "demo_pipeline")
+        self.assertIn("demo_pipeline", payload["snapshot"]["pipelines"])
+        self.assertEqual(payload["snapshot"]["currentPlan"][0]["id"], "implement")
+        self.assertEqual(payload["repoPath"], self.repo_path)
+        self.assertIn("defaultOpenClawAgentId", payload)
+
+    async def test_index_serves_readiness_and_output_controls(self) -> None:
+        response = await self.client.get("/")
+        self.assertEqual(response.status, 200)
+        page = await response.text()
+
+        self.assertIn("Readiness Gate", page)
+        self.assertIn('id="readiness-checks"', page)
+        self.assertIn('id="result-filter"', page)
+        self.assertIn('id="copy-run-summary"', page)
+        self.assertIn('id="copy-issue-update"', page)
+        self.assertIn('id="copy-pr-note"', page)
+
+    async def test_health_endpoint_returns_snapshot(self) -> None:
+        fake_health = {
+            "checkedAt": "2026-04-16T00:00:00Z",
+            "agentId": "openclaw-control-ext",
+            "healthOk": True,
+            "defaultAgentId": "main",
+            "targetAgentPresent": True,
+            "channels": [],
+            "gateway": {"ok": True, "stdout": "Gateway: ok", "stderr": ""},
+            "memory": {"ok": True, "stdout": "Embeddings: ready", "stderr": ""},
+        }
+        with mock.patch("openclaw_v2.web._openclaw_health_snapshot", return_value=fake_health):
+            response = await self.client.get("/api/system/health?agentId=openclaw-control-ext")
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["agentId"], "openclaw-control-ext")
+        self.assertTrue(payload["healthOk"])
+
+    async def test_history_endpoints_return_files_and_content(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-1")
+        os.makedirs(os.path.join(run_dir, "prompts"), exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-1", "plan": [], "results": [], "success": True}, handle)
+        with open(os.path.join(run_dir, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "demo"}, handle)
+        with open(os.path.join(run_dir, "prompts", "implement.txt"), "w", encoding="utf-8") as handle:
+            handle.write("hello prompt\n")
+
+        response = await self.client.get("/api/history/run-1")
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-1")
+        self.assertEqual(payload["files"][0]["path"], "context.json")
+
+        file_response = await self.client.get("/api/history/run-1/file?path=prompts/implement.txt")
+        self.assertEqual(file_response.status, 200)
+        file_payload = await file_response.json()
+        self.assertIn("hello prompt", file_payload["content"])
+
+    async def test_cleanup_endpoint_removes_run_directory(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-cleanup")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-cleanup", "plan": [], "results": [], "success": True}, handle)
+
+        response = await self.client.post("/api/history/run-cleanup/cleanup", json={})
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-cleanup")
+        self.assertFalse(os.path.exists(run_dir))
+
+    async def test_prune_endpoint_keeps_latest_runs(self) -> None:
+        runs_root = os.path.join(self.repo_path, ".openclaw", "runs")
+        os.makedirs(runs_root, exist_ok=True)
+        for index, run_id in enumerate(["run-a", "run-b", "run-c"], start=1):
+            run_dir = os.path.join(runs_root, run_id)
+            os.makedirs(run_dir, exist_ok=True)
+            with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+                json.dump({"run_id": run_id, "plan": [], "results": [], "success": True}, handle)
+            os.utime(run_dir, (index, index))
+
+        response = await self.client.post("/api/history/prune", json={"keepLatest": 1})
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(len(payload["removed"]), 2)
+        self.assertTrue(os.path.exists(os.path.join(runs_root, "run-c")))
+        self.assertFalse(os.path.exists(os.path.join(runs_root, "run-a")))
+        self.assertFalse(os.path.exists(os.path.join(runs_root, "run-b")))
+
+
+class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
+    async def asyncSetUp(self) -> None:
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.repo_path = self.temp_dir.name
+        self.config_path = os.path.join(self.repo_path, "config_v2.yaml")
+        _write_minimal_config(self.config_path)
+        self.client = TestClient(
+            TestServer(
+                create_web_app(
+                    config_path=self.config_path,
+                    repo_path=self.repo_path,
+                )
+            )
+        )
+        await self.client.start_server()
+
+    async def asyncTearDown(self) -> None:
+        await self.client.close()
+        self.temp_dir.cleanup()
+
+    async def test_run_task_captures_progress_and_result(self) -> None:
+        run_artifacts = os.path.join(self.repo_path, ".openclaw", "runs", "run-web-test")
+        os.makedirs(run_artifacts, exist_ok=True)
+        with open(os.path.join(run_artifacts, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "run_id": "run-web-test",
+                    "plan": [],
+                    "results": [
+                        {
+                            "work_item_id": "implement",
+                            "status": "succeeded",
+                            "summary": "Implementation finished.",
+                        }
+                    ],
+                    "success": True,
+                    "artifacts_dir": run_artifacts,
+                },
+                handle,
+            )
+        with open(os.path.join(run_artifacts, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "Add a Web UI"}, handle)
+
+        fake_run_result = RunResult(
+            run_id="run-web-test",
+            plan=[
+                WorkItem(
+                    id="implement",
+                    title="Implement docs",
+                    profile="codex_local",
+                    agent=AgentType.CODEX,
+                    mode=ExecutionMode.CLI,
+                    prompt_template="prompt",
+                    assignment="implement_local",
+                    managed_agent="codex_builder",
+                )
+            ],
+            results=[
+                AgentResult(
+                    work_item_id="implement",
+                    profile="codex_local",
+                    agent=AgentType.CODEX,
+                    mode=ExecutionMode.CLI,
+                    status=TaskStatus.SUCCEEDED,
+                    summary="Implementation finished.",
+                )
+            ],
+            success=True,
+            artifacts_dir=os.path.join(self.repo_path, ".openclaw", "runs", "run-web-test"),
+        )
+
+        class FakeOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+
+            def build_plan(self, selected_steps=None):
+                return []
+
+            async def run(self, user_request, repo_path, selected_steps=None, progress_callback=None):
+                if progress_callback is not None:
+                    progress_callback("preflight:start")
+                    progress_callback("step:done implement -> succeeded")
+                return fake_run_result
+
+        with mock.patch("openclaw_v2.web.HybridOrchestrator", FakeOrchestrator):
+            response = await self.client.post(
+                "/api/tasks",
+                json={
+                    "action": "run",
+                    "repoPath": self.repo_path,
+                    "configPath": self.config_path,
+                    "pipeline": "demo_pipeline",
+                    "request": "Add a Web UI",
+                    "steps": ["implement"],
+                    "live": False,
+                },
+            )
+            self.assertEqual(response.status, 202)
+            payload = await response.json()
+            task_id = payload["task"]["id"]
+
+            task_payload = None
+            for _ in range(20):
+                detail_response = await self.client.get(f"/api/tasks/{task_id}")
+                self.assertEqual(detail_response.status, 200)
+                detail = await detail_response.json()
+                task_payload = detail["task"]
+                if task_payload["status"] == "completed":
+                    break
+                await asyncio.sleep(0.01)
+
+            self.assertIsNotNone(task_payload)
+            self.assertEqual(task_payload["status"], "completed")
+            messages = [item["message"] for item in task_payload["progress"]]
+            self.assertIn("preflight:start", messages)
+            self.assertIn("step:done implement -> succeeded", messages)
+            self.assertEqual(task_payload["result"]["mode"], "run")
+            self.assertEqual(task_payload["result"]["runResult"]["run_id"], "run-web-test")
+            self.assertEqual(task_payload["result"]["history"]["runId"], "run-web-test")
+
+    async def test_cancel_run_task_marks_task_cancelled(self) -> None:
+        started = asyncio.Event()
+
+        class SlowOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+
+            def build_plan(self, selected_steps=None):
+                return []
+
+            async def run(self, user_request, repo_path, selected_steps=None, progress_callback=None):
+                if progress_callback is not None:
+                    progress_callback("preflight:start")
+                started.set()
+                await asyncio.sleep(60)
+                raise AssertionError("run should have been cancelled")
+
+        with mock.patch("openclaw_v2.web.HybridOrchestrator", SlowOrchestrator):
+            response = await self.client.post(
+                "/api/tasks",
+                json={
+                    "action": "run",
+                    "repoPath": self.repo_path,
+                    "configPath": self.config_path,
+                    "pipeline": "demo_pipeline",
+                    "request": "Cancel me",
+                    "steps": ["implement"],
+                    "live": False,
+                },
+            )
+            self.assertEqual(response.status, 202)
+            payload = await response.json()
+            task_id = payload["task"]["id"]
+
+            await asyncio.wait_for(started.wait(), timeout=1)
+
+            cancel_response = await self.client.post(f"/api/tasks/{task_id}/cancel")
+            self.assertEqual(cancel_response.status, 200)
+
+            task_payload = None
+            for _ in range(30):
+                detail_response = await self.client.get(f"/api/tasks/{task_id}")
+                self.assertEqual(detail_response.status, 200)
+                detail = await detail_response.json()
+                task_payload = detail["task"]
+                if task_payload["status"] == "cancelled":
+                    break
+                await asyncio.sleep(0.01)
+
+            self.assertIsNotNone(task_payload)
+            self.assertEqual(task_payload["status"], "cancelled")
+            self.assertEqual(task_payload["error"], "Cancelled by user.")
+
+    async def test_task_events_endpoint_streams_task_payload(self) -> None:
+        run_artifacts = os.path.join(self.repo_path, ".openclaw", "runs", "run-stream-test")
+        os.makedirs(run_artifacts, exist_ok=True)
+        with open(os.path.join(run_artifacts, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "run_id": "run-stream-test",
+                    "plan": [],
+                    "results": [],
+                    "success": True,
+                    "artifacts_dir": run_artifacts,
+                },
+                handle,
+            )
+        with open(os.path.join(run_artifacts, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "stream demo"}, handle)
+
+        fake_run_result = RunResult(
+            run_id="run-stream-test",
+            plan=[],
+            results=[],
+            success=True,
+            artifacts_dir=run_artifacts,
+        )
+
+        class InstantOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+
+            def build_plan(self, selected_steps=None):
+                return []
+
+            async def run(self, user_request, repo_path, selected_steps=None, progress_callback=None):
+                if progress_callback is not None:
+                    progress_callback("step:done implement -> succeeded")
+                return fake_run_result
+
+        with mock.patch("openclaw_v2.web.HybridOrchestrator", InstantOrchestrator):
+            response = await self.client.post(
+                "/api/tasks",
+                json={
+                    "action": "run",
+                    "repoPath": self.repo_path,
+                    "configPath": self.config_path,
+                    "pipeline": "demo_pipeline",
+                    "request": "Stream me",
+                    "steps": ["implement"],
+                    "live": False,
+                },
+            )
+            self.assertEqual(response.status, 202)
+            payload = await response.json()
+            task_id = payload["task"]["id"]
+
+            events_response = await self.client.get(f"/api/tasks/{task_id}/events")
+            self.assertEqual(events_response.status, 200)
+            body = await events_response.text()
+            self.assertIn("event: task", body)
+            self.assertIn('"status": "completed"', body)


### PR DESCRIPTION
## What this changes
- add a Mission Control Web UI entrypoint via `python3 main_v2.py --web`
- add an aiohttp dashboard backend for bootstrap, health, task streaming, run history, artifact browsing, and cleanup
- add a frontend control deck with launch controls, OpenClaw health, recent runs, artifact browsing, result filtering, copy helpers, and a readiness gate
- make orchestrator run ids collision-resistant with a short UUID suffix
- document the Web UI usage in `README.md`
- add Web UI regression tests

## Validation
- `node --check openclaw_v2/webui/app.js`
- `python3 -m unittest discover -s tests`
- local Web UI boot on `http://127.0.0.1:8766/`
- local OpenClaw health checks (`openclaw health --json`, gateway status, memory status)
- GitHub review workflow on current head `f4d41c9`: https://github.com/crused-fall/Openclaw-AIagent-control/actions/runs/25115019545

## Notes
- the readiness gate stays frontend-side and derives from bootstrap, health, preflight, and current form state
- this keeps the active architecture centered on `main_v2.py` + `openclaw_v2/`

## Review state
- This PR is ready for human review.
- The branch remains the stacked base for `codex/web-ui-control-room`.
