### PR TITLE
Add Hermes supervisor and recorder pipeline

### DIFF
--- a/FRAMEWORK_V2.md
+++ b/FRAMEWORK_V2.md
@@ -15,6 +15,7 @@ v1 的关键词路由原型继续保留，但不再代表项目长期方向。
 - 长期目标仍然是 OpenClaw 风格的统一总控
 - 当前真正落地的控制层是 `main_v2.py` + `openclaw_v2/`
 - `ExecutionMode.OPENCLAW` 只是已接入的一种执行路径，不等于仓库已经由外部 OpenClaw 完全接管
+- `ExecutionMode.HERMES` 当前定位为本机监督 / 记录执行路径，不承担默认实现步骤
 
 ## 分层映射
 
@@ -46,6 +47,7 @@ v1 的关键词路由原型继续保留，但不再代表项目长期方向。
 ### 3. Execution Layer
 
 - `executors/cli.py`
+- `executors/hermes.py`
 - `executors/openclaw.py`
 - `executors/github.py`
 
@@ -53,6 +55,7 @@ v1 的关键词路由原型继续保留，但不再代表项目长期方向。
 
 - 统一执行接口
 - 把本地 CLI、本机 OpenClaw、GitHub 协作接进同一条编排链
+- 把 Hermes 这类本机 supervisor / recorder executor 接进同一条编排链
 - 将 stdout / stderr / 结果结构化成 `AgentResult`
 
 ### 3.5 Managed-Agent Registry
@@ -118,6 +121,22 @@ request
 
 1. `dispatch_review`
 2. `collect_review`
+
+另有一条 Hermes 监督变体：
+
+`mission_control_hermes_supervised`
+
+1. `triage`（Hermes）
+2. `implement`（本地 CLI）
+3. `review`（Hermes）
+4. `commit_changes`
+5. `publish_branch`
+6. `sync_issue`
+7. `record_summary`（Hermes）
+8. `update_issue`
+9. `draft_pr`
+10. `dispatch_review`
+11. `collect_review`
 
 这条链专门用于绕过本地 `triage/implement/review`，单独验证 review workflow 的触发和状态回流。
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -70,6 +70,7 @@
 - 任务拆分仍然是静态 pipeline，不是智能动态 planner
 - OpenClaw 接入骨架已落地，但目前只安全接到 `triage` 变体 pipeline
 - OpenClaw 已验证“仓库外 workspace + repo 绝对路径 handoff”可运行，当前已有 `mission_control_openclaw_triage` 和 `mission_control_openclaw_default` 两条变体 pipeline
+- Hermes 已作为本机 `supervisor + recorder` 接入，新增 `mission_control_hermes_supervised` 变体 pipeline，但不承担 `implement`
 - `Gemini` 和 `Cursor` 已进入受控 agent 注册表，但还没进入默认 assignment
 - 当前 fallback 仍是静态配置回退，不是实时在线调度
 - live 模式下已默认禁止 fallback managed agent 静默执行

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ tests/
 - 当前这样设计是为了先替换最容易受 Claude 环境影响的监督层，不把 gateway / ACP 问题一次性扩大
 - OpenClaw executor 会显式把 repo 绝对路径传给 agent，并要求它先读取 repo 内的 `AGENTS.md`
 
+另有一条 Hermes 监督变体 pipeline：
+
+- `mission_control_hermes_supervised`：让 Hermes 承担 `triage + review + record_summary`
+- `implement` 仍保持本地 CLI 执行，不让 Hermes 直接做实现
+- `record_summary` 会在 `publish_branch + sync_issue + review` 之后整理协作记录，供 `update_issue` 和 `draft_pr` 继续复用
+- 适合把 Hermes 当成 supervisor + recorder，而不是 implementer
+- 这条变体默认复用你本机 `~/.hermes/config.yaml` 的 provider / model，不强行覆盖 Hermes 自身配置
+
 另有一条 GitHub-only smoke pipeline：`github_bridge_smoke`
 
 - 只跑 `dispatch_review -> collect_review`
@@ -134,6 +142,7 @@ gh auth login
 - `codex`
 - `cursor-agent`
 - `openclaw`
+- `hermes`
 
 如果要验证本机 OpenClaw 接入，再额外准备：
 
@@ -146,6 +155,16 @@ export OPENCLAW_AGENT_ID="your-openclaw-agent-id"
 
 推荐把 OpenClaw agent 的 workspace 放在仓库外，再把仓库绝对路径交给 executor。
 不要长期把 workspace 直接指到 repo 根目录。
+
+如果要启用 Hermes 监督/记录变体，先确认本机 `hermes` 可用：
+
+```bash
+hermes --version
+hermes doctor
+```
+
+如果 Hermes 走的是本机自定义 OpenAI-compatible endpoint，这个 endpoint 还需要支持 tool calling / function calling；
+否则 Hermes 虽然能聊天，但无法稳定驱动 `file` / `terminal` 这类监督步骤。
 
 如果你的 `claude` 依赖自定义 `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN`，当前默认 `claude_local` 会保留这些环境变量。
 仓库里还提供了一个隔离版 `claude_local_isolated`，只在你需要显式绕过这两个变量时使用。
@@ -171,6 +190,14 @@ python3 main_v2.py --list-steps --steps triage
 
 ```bash
 python3 main_v2.py --request "修复登录页报错" --steps triage,implement,review
+```
+
+如果你想让 Hermes 承担 supervisor + recorder，但不接 implement：
+
+```bash
+python3 main_v2.py --pipeline mission_control_hermes_supervised \
+  --request "修复登录页报错" \
+  --steps triage,implement,review,record_summary
 ```
 
 如果你只想验证 GitHub review workflow，不想先经过本地 `triage/implement/review`：

--- a/config_v2.yaml
+++ b/config_v2.yaml
@@ -16,6 +16,7 @@ runtime:
     - triage
     - implement
     - review
+    - record_summary
     - commit_changes
     - publish_branch
     - sync_issue
@@ -66,6 +67,16 @@ profiles:
     openclaw_agent_id: ${OPENCLAW_AGENT_ID}
     openclaw_profile: ${OPENCLAW_PROFILE}
     openclaw_local: true
+
+  hermes_local:
+    agent: hermes
+    mode: hermes
+    hermes_toolsets:
+      - file
+      - terminal
+      - todo
+    hermes_source: tool
+    hermes_max_turns: 40
 
   codex_local:
     agent: codex
@@ -219,6 +230,21 @@ managed_agents:
       - implement
     manager: openclaw
 
+  hermes_supervisor:
+    kind: hermes
+    profile: hermes_local
+    capabilities:
+      - triage
+      - review
+    manager: openclaw
+
+  hermes_scribe:
+    kind: hermes
+    profile: hermes_local
+    capabilities:
+      - record_summary
+    manager: openclaw
+
   git_branch_publisher:
     kind: system
     profile: git_push_branch
@@ -281,6 +307,12 @@ assignments:
     required_capabilities:
       - triage
 
+  triage_hermes:
+    agent: hermes_supervisor
+    manager: openclaw
+    required_capabilities:
+      - triage
+
   implement_local:
     agent: codex_builder
     manager: openclaw
@@ -300,6 +332,18 @@ assignments:
     manager: openclaw
     required_capabilities:
       - review
+
+  review_hermes:
+    agent: hermes_supervisor
+    manager: openclaw
+    required_capabilities:
+      - review
+
+  record_summary_hermes:
+    agent: hermes_scribe
+    manager: openclaw
+    required_capabilities:
+      - record_summary
 
   research_local:
     agent: gemini_researcher
@@ -1170,6 +1214,270 @@ pipelines:
         - publish_branch
         - review
         - sync_issue
+        - update_issue
+      prompt_template: |
+        请把本地实现结果整理为 Draft PR 描述，便于后续人工审核和合并。
+
+        用户请求：
+        {user_request}
+
+        {dependency_summaries}
+
+        建议使用的实现分支：
+        {primary_branch_name}
+
+    - id: dispatch_review
+      title: Trigger GitHub review workflow
+      assignment: dispatch_review_bridge
+      depends_on:
+        - publish_branch
+        - review
+        - draft_pr
+      prompt_template: |
+        请触发 GitHub review workflow，对以下实现分支执行异步检查。
+
+        用户请求：
+        {user_request}
+
+        推荐分支：
+        {primary_branch_name}
+
+        {dependency_summaries}
+
+    - id: collect_review
+      title: Collect GitHub review workflow status
+      assignment: collect_review_bridge
+      depends_on:
+        - dispatch_review
+      prompt_template: |
+        请收集当前 GitHub review workflow 的最新状态，便于 OpenClaw 回流异步检查结果。
+
+        用户请求：
+        {user_request}
+
+        目标 workflow run：
+        {primary_workflow_run_ref}
+
+        {dependency_summaries}
+
+  mission_control_hermes_supervised:
+    - id: triage
+      title: Triage user request with local Hermes
+      assignment: triage_hermes
+      metadata:
+        export_branch: false
+      prompt_template: |
+        你是 OpenClaw 的需求拆解与监督 agent，当前由 Hermes 承担。
+        运行编号：{run_id}
+        仓库路径：{repo_path}
+        Artifacts 目录：{artifacts_dir}
+
+        用户请求：
+        {user_request}
+
+        如果请求与当前仓库不匹配、缺少关键文件或模块、或者信息不足以安全继续，请严格先输出两行，不要加粗、不要列表、不要加任何 Markdown 修饰：
+        OPENCLAW_STATUS: blocked
+        OPENCLAW_BLOCK_REASON: <一句话说明阻塞原因>
+
+        如果可以继续，请严格先输出下面这一行，不要加任何 Markdown 修饰：
+        OPENCLAW_STATUS: ready
+
+        请输出：
+        1. 任务拆分
+        2. 风险点
+        3. 实施顺序
+
+    - id: implement
+      title: Implement main changes locally
+      assignment: implement_local
+      depends_on:
+        - triage
+      metadata:
+        export_branch: true
+        expects_file_changes: true
+      prompt_template: |
+        你是 OpenClaw 的本地实现 agent。
+        基于以下用户请求和依赖结果，在本地工作区准备实现方案。
+        工作目录：{workspace_path}
+        分支名：{branch_name}
+
+        用户请求：
+        {user_request}
+
+        {dependency_summaries}
+
+        请先确认用户请求对应的目标文件、模块或页面在当前仓库中确实存在。
+        如果请求与仓库不匹配、目标代码不存在、或关键信息缺失，请不要编造实现方案，严格先输出两行，不要加粗、不要列表、不要加任何 Markdown 修饰：
+        OPENCLAW_STATUS: blocked
+        OPENCLAW_BLOCK_REASON: <一句话说明阻塞原因>
+
+        如果可以继续，请严格先输出下面这一行，不要加任何 Markdown 修饰：
+        OPENCLAW_STATUS: ready
+
+        请重点关注：
+        1. 需要修改的文件
+        2. 实施步骤
+        3. 验证方式
+
+    - id: review
+      title: Review implementation before publish with Hermes
+      assignment: review_hermes
+      depends_on:
+        - implement
+      prompt_template: |
+        你是 OpenClaw 的本地审阅与监督 agent，当前由 Hermes 承担。
+        请基于实现结果判断当前分支是否适合进入 GitHub 协作流程。
+
+        实现步骤可能运行在独立 worktree / 分支中，这属于预期，不要因为改动尚未回到仓库根目录就判断为流程错误。
+        如果依赖结果提供了实现分支或实现工作目录，请优先基于这些实现产物审阅；下游 `commit_changes` / `publish_branch` 会继续在实现分支上处理。
+        不要建议把改动手工复制回当前仓库根目录，除非依赖结果明确显示实现分支或实现工作目录缺失。
+
+        工作目录：
+        {workspace_path}
+
+        实现分支：
+        {source_branch}
+
+        实现工作目录：
+        {source_workspace_path}
+
+        用户请求：
+        {user_request}
+
+        {dependency_summaries}
+
+        如果实现结果不足以继续、需求与仓库不匹配、或者必须先补充人工信息，请严格先输出两行，不要加任何 Markdown 修饰：
+        OPENCLAW_STATUS: blocked
+        OPENCLAW_BLOCK_REASON: <一句话说明阻塞原因>
+
+        如果可以继续，请严格先输出下面这一行，不要加任何 Markdown 修饰：
+        OPENCLAW_STATUS: ready
+
+        请输出：
+        1. 主要风险
+        2. 建议补充验证
+        3. 是否建议发布到 GitHub 流程
+
+    - id: commit_changes
+      title: Commit implementation changes locally
+      assignment: commit_changes_local
+      depends_on:
+        - implement
+        - review
+      metadata:
+        export_branch: true
+        requires_workspace_changes: true
+        requires_dependency_branch: true
+        reuse_source_workspace: true
+        commits_workspace_changes: true
+      prompt_template: |
+        OpenClaw: apply requested changes
+
+    - id: publish_branch
+      title: Publish implementation branch to origin
+      assignment: publish_branch_local
+      depends_on:
+        - commit_changes
+        - review
+      metadata:
+        export_branch: true
+        requires_origin_remote: true
+        requires_workspace_changes: true
+        requires_dependency_branch: true
+        requires_committed_dependency_changes: true
+      prompt_template: |
+        将当前实现分支推送到 origin，供 GitHub PR 和 workflow 使用。
+        工作目录：{workspace_path}
+        分支名：{branch_name}
+
+        用户请求：
+        {user_request}
+
+        来源分支：
+        {source_branch}
+
+    - id: sync_issue
+      title: Sync planning issue to GitHub
+      assignment: sync_issue_bridge
+      depends_on:
+        - triage
+      prompt_template: |
+        请把以下任务分析整理成 GitHub issue，便于异步跟踪。
+
+        用户请求：
+        {user_request}
+
+        {dependency_summaries}
+
+    - id: record_summary
+      title: Record collaboration summary with Hermes
+      assignment: record_summary_hermes
+      depends_on:
+        - publish_branch
+        - review
+        - sync_issue
+      metadata:
+        allow_noop_skipped_dependencies:
+          - publish_branch
+      prompt_template: |
+        你是 OpenClaw 的记录员 agent，当前由 Hermes 承担。
+        请基于已有依赖结果整理一份异步协作记录，供后续 issue / PR / review 使用。
+
+        要求：
+        - 只根据依赖结果总结，不要编造不存在的提交、分支、PR、workflow 结果
+        - 如果 `publish_branch` 因为无文件改动而跳过，要明确写明是 noop，而不是失败
+        - 这是记录与总结步骤，不要修改代码或 Git 状态
+
+        用户请求：
+        {user_request}
+
+        当前实现分支：
+        {primary_branch_name}
+
+        目标 issue：
+        {primary_issue_ref}
+
+        {dependency_summaries}
+
+        请输出：
+        1. 执行摘要
+        2. 关键风险与未决点
+        3. 建议同步到 issue / PR 的简短说明
+        4. 下一步建议
+
+    - id: update_issue
+      title: Update GitHub issue with implementation status
+      assignment: update_issue_bridge
+      depends_on:
+        - publish_branch
+        - review
+        - sync_issue
+        - record_summary
+      metadata:
+        allow_noop_skipped_dependencies:
+          - publish_branch
+      prompt_template: |
+        请把本地实现结果回写到现有 GitHub issue，作为阶段性进展更新。
+
+        用户请求：
+        {user_request}
+
+        当前实现分支：
+        {primary_branch_name}
+
+        目标 issue：
+        {primary_issue_ref}
+
+        {dependency_summaries}
+
+    - id: draft_pr
+      title: Prepare GitHub draft PR summary
+      assignment: draft_pr_bridge
+      depends_on:
+        - publish_branch
+        - review
+        - sync_issue
+        - record_summary
         - update_issue
       prompt_template: |
         请把本地实现结果整理为 Draft PR 描述，便于后续人工审核和合并。

--- a/openclaw_v2/config.py
+++ b/openclaw_v2/config.py
@@ -30,7 +30,9 @@ class RuntimeConfig:
     github_retry_backoff_seconds: float = 1.0
     github_workflow_view_poll_attempts: int = 1
     github_workflow_view_poll_interval_seconds: float = 2.0
-    allowed_live_steps: list[str] = field(default_factory=lambda: ["triage", "implement", "review", "publish_branch"])
+    allowed_live_steps: list[str] = field(
+        default_factory=lambda: ["triage", "implement", "review", "record_summary", "publish_branch"]
+    )
 
 
 @dataclass
@@ -56,6 +58,13 @@ class ProfileConfig:
     openclaw_agent_id: str = ""
     openclaw_profile: str = ""
     openclaw_local: bool = True
+    hermes_provider: str = ""
+    hermes_model: str = ""
+    hermes_toolsets: list[str] = field(default_factory=list)
+    hermes_skills: list[str] = field(default_factory=list)
+    hermes_source: str = "tool"
+    hermes_max_turns: int = 0
+    hermes_yolo: bool = False
 
 
 @dataclass
@@ -494,6 +503,13 @@ def load_app_config(path: str) -> AppConfig:
             openclaw_agent_id=raw.get("openclaw_agent_id", ""),
             openclaw_profile=raw.get("openclaw_profile", ""),
             openclaw_local=raw.get("openclaw_local", True),
+            hermes_provider=raw.get("hermes_provider", ""),
+            hermes_model=raw.get("hermes_model", ""),
+            hermes_toolsets=raw.get("hermes_toolsets", []),
+            hermes_skills=raw.get("hermes_skills", []),
+            hermes_source=raw.get("hermes_source", "tool"),
+            hermes_max_turns=raw.get("hermes_max_turns", 0),
+            hermes_yolo=raw.get("hermes_yolo", False),
         )
 
     managed_agents: dict[str, ManagedAgentConfig] = {}

--- a/openclaw_v2/executors/__init__.py
+++ b/openclaw_v2/executors/__init__.py
@@ -1,5 +1,6 @@
 from .cli import CLIExecutor
 from .github import GitHubWorkflowExecutor
+from .hermes import HermesExecutor
 from .openclaw import OpenClawExecutor
 
-__all__ = ["CLIExecutor", "GitHubWorkflowExecutor", "OpenClawExecutor"]
+__all__ = ["CLIExecutor", "GitHubWorkflowExecutor", "HermesExecutor", "OpenClawExecutor"]

--- a/openclaw_v2/executors/hermes.py
+++ b/openclaw_v2/executors/hermes.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+
+from ..config import ProfileConfig
+from ..models import AgentResult, ExecutionContext, TaskStatus, WorkItem, parse_control_output
+from .base import Executor
+
+
+class HermesExecutor(Executor):
+    """Run local Hermes turns for supervision and recording steps."""
+
+    _SESSION_PATTERNS = [
+        re.compile(r"^Resume this session with:\s*$", re.IGNORECASE),
+        re.compile(r"^hermes\s+(?:chat\s+)?(?:--resume|-r)\s+\S+.*$", re.IGNORECASE),
+        re.compile(r"^Session:\s*(\S+)\s*$", re.IGNORECASE),
+        re.compile(r"^Duration:\s+.+$", re.IGNORECASE),
+        re.compile(r"^Messages:\s+.+$", re.IGNORECASE),
+    ]
+
+    @staticmethod
+    def _artifacts(
+        work_item: WorkItem,
+        workspace_path: str,
+        exports_branch: bool,
+        blocked_reason: str = "",
+    ) -> dict[str, object]:
+        artifacts: dict[str, object] = {
+            "workspace_path": workspace_path,
+            "branch_name": work_item.branch_name,
+            "exports_branch": exports_branch,
+            "source_branch": work_item.branch_name if exports_branch else "",
+            "workspace_prepare_command": work_item.metadata.get("workspace_prepare_command", []),
+        }
+        if blocked_reason:
+            artifacts["blocked_reason"] = blocked_reason
+        return artifacts
+
+    @staticmethod
+    def _prepare_prompt(
+        rendered_prompt: str,
+        context: ExecutionContext,
+        work_item: WorkItem,
+    ) -> str:
+        target_path = work_item.workspace_path or context.repo_path
+        agents_path = os.path.join(target_path, "AGENTS.md")
+        lines = [
+            "Hermes repository handoff:",
+            f"- Primary repository path: {target_path}",
+            f"- If `{agents_path}` exists, read it before acting.",
+            "- Use absolute paths under the repository path when you inspect files.",
+            "- Do not edit files unless the task explicitly asks for implementation.",
+            "",
+            rendered_prompt.strip(),
+        ]
+        return "\n".join(lines).strip()
+
+    @staticmethod
+    def _csv(values: list[str]) -> str:
+        return ",".join(value.strip() for value in values if value.strip())
+
+    @classmethod
+    def _build_command(cls, profile: ProfileConfig, prepared_prompt: str) -> list[str]:
+        command = [
+            "hermes",
+            "chat",
+            "-q",
+            prepared_prompt,
+            "-Q",
+            "--source",
+            profile.hermes_source.strip() or "tool",
+        ]
+        provider = profile.hermes_provider.strip()
+        if provider:
+            command.extend(["--provider", provider])
+
+        model = profile.hermes_model.strip()
+        if model:
+            command.extend(["--model", model])
+
+        toolsets = cls._csv(profile.hermes_toolsets)
+        if toolsets:
+            command.extend(["--toolsets", toolsets])
+
+        skills = cls._csv(profile.hermes_skills)
+        if skills:
+            command.extend(["--skills", skills])
+
+        if profile.hermes_max_turns > 0:
+            command.extend(["--max-turns", str(int(profile.hermes_max_turns))])
+
+        if profile.hermes_yolo:
+            command.append("--yolo")
+
+        return command
+
+    @classmethod
+    def _strip_session_footer(cls, output: str) -> tuple[str, str]:
+        lines = output.splitlines()
+        tail = len(lines)
+        while tail > 0 and not lines[tail - 1].strip():
+            tail -= 1
+
+        session_id = ""
+        start = tail
+        while start > 0:
+            stripped = lines[start - 1].strip()
+            if not stripped and start < tail:
+                start -= 1
+                continue
+
+            matched = False
+            for pattern in cls._SESSION_PATTERNS:
+                match = pattern.match(stripped)
+                if not match:
+                    continue
+                matched = True
+                if stripped.lower().startswith("session:"):
+                    session_id = match.group(1).strip()
+                start -= 1
+                break
+
+            if not matched:
+                break
+
+        cleaned_output = "\n".join(lines[:start]).strip()
+        if not cleaned_output:
+            cleaned_output = output.strip()
+        return cleaned_output, session_id
+
+    async def execute(
+        self,
+        work_item: WorkItem,
+        profile: ProfileConfig,
+        context: ExecutionContext,
+        rendered_prompt: str,
+    ) -> AgentResult:
+        prepared_prompt = self._prepare_prompt(rendered_prompt, context, work_item)
+        command = self._build_command(profile, prepared_prompt)
+        workspace_path = work_item.workspace_path or context.repo_path
+        artifacts = self._artifacts(
+            work_item,
+            workspace_path,
+            exports_branch=bool(work_item.metadata.get("export_branch", False)),
+        )
+        artifacts.update(
+            {
+                "hermes_provider": profile.hermes_provider,
+                "hermes_model": profile.hermes_model,
+                "hermes_toolsets": list(profile.hermes_toolsets),
+                "hermes_skills": list(profile.hermes_skills),
+                "hermes_source": profile.hermes_source,
+                "hermes_max_turns": profile.hermes_max_turns,
+                "hermes_yolo": profile.hermes_yolo,
+                "hermes_prepared_prompt": prepared_prompt,
+            }
+        )
+
+        if context.dry_run:
+            return AgentResult(
+                work_item_id=work_item.id,
+                profile=work_item.profile,
+                agent=work_item.agent,
+                mode=work_item.mode,
+                status=TaskStatus.SUCCEEDED,
+                summary=f"Dry-run only. Planned Hermes command for {work_item.title}.",
+                output=prepared_prompt,
+                stdout=prepared_prompt,
+                exit_code=0,
+                command=command,
+                artifacts=artifacts,
+            )
+
+        process = await asyncio.create_subprocess_exec(
+            *command,
+            cwd=workspace_path,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await process.communicate()
+        output = stdout.decode("utf-8", errors="replace").strip()
+        error_output = stderr.decode("utf-8", errors="replace").strip()
+
+        if process.returncode != 0:
+            return AgentResult(
+                work_item_id=work_item.id,
+                profile=work_item.profile,
+                agent=work_item.agent,
+                mode=work_item.mode,
+                status=TaskStatus.FAILED,
+                summary=f"Hermes task {work_item.title} failed with exit code {process.returncode}.",
+                output=error_output or output,
+                stdout=output,
+                stderr=error_output,
+                exit_code=process.returncode,
+                command=command,
+                artifacts=artifacts,
+            )
+
+        cleaned_stdout, session_id = self._strip_session_footer(output)
+        if session_id:
+            artifacts["hermes_session_id"] = session_id
+
+        control_signal = parse_control_output(cleaned_stdout)
+        status = control_signal.status or TaskStatus.SUCCEEDED
+        cleaned_output = control_signal.cleaned_output or cleaned_stdout
+        blocked_reason = control_signal.block_reason
+        if blocked_reason:
+            artifacts["blocked_reason"] = blocked_reason
+
+        summary = (
+            f"Hermes task {work_item.title} blocked: {blocked_reason}"
+            if status == TaskStatus.BLOCKED
+            else f"Hermes task {work_item.title} finished successfully."
+        )
+
+        return AgentResult(
+            work_item_id=work_item.id,
+            profile=work_item.profile,
+            agent=work_item.agent,
+            mode=work_item.mode,
+            status=status,
+            summary=summary,
+            output=cleaned_output,
+            stdout=output,
+            stderr=error_output,
+            exit_code=process.returncode,
+            command=command,
+            artifacts=artifacts,
+        )

--- a/openclaw_v2/models.py
+++ b/openclaw_v2/models.py
@@ -12,6 +12,7 @@ class AgentType(str, Enum):
     CODEX = "codex"
     CURSOR = "cursor"
     OPENCLAW = "openclaw"
+    HERMES = "hermes"
     COPILOT = "copilot"
     ANTIGRAVITY = "antigravity"
     SYSTEM = "system"
@@ -21,6 +22,7 @@ class ExecutionMode(str, Enum):
     CLI = "cli"
     GITHUB = "github"
     OPENCLAW = "openclaw"
+    HERMES = "hermes"
     SYSTEM = "system"
 
 

--- a/openclaw_v2/orchestrator.py
+++ b/openclaw_v2/orchestrator.py
@@ -7,7 +7,7 @@ from typing import Callable
 
 from .artifacts import ArtifactStore
 from .config import AppConfig, resolve_runtime_path
-from .executors import CLIExecutor, GitHubWorkflowExecutor, OpenClawExecutor
+from .executors import CLIExecutor, GitHubWorkflowExecutor, HermesExecutor, OpenClawExecutor
 from .models import AgentResult, CheckStatus, ExecutionContext, ExecutionMode, RunResult, TaskStatus, WorkItem
 from .planner import PipelinePlanner
 from .preflight import PreflightRunner
@@ -26,6 +26,7 @@ class HybridOrchestrator:
         self.executors = {
             ExecutionMode.CLI: CLIExecutor(config),
             ExecutionMode.GITHUB: GitHubWorkflowExecutor(config),
+            ExecutionMode.HERMES: HermesExecutor(config),
             ExecutionMode.OPENCLAW: OpenClawExecutor(config),
         }
 

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -5,7 +5,7 @@ import json
 import os
 import shutil
 
-from .config import AppConfig
+from .config import AppConfig, _load_yaml
 from .github_support import resolve_github_repo_from_origin
 from .models import CheckStatus, ExecutionMode, PreflightCheck, PreflightReport, WorkItem
 
@@ -24,6 +24,8 @@ class PreflightRunner:
         checks.extend(self._check_managed_assignments(plan))
         checks.extend(await self._check_required_commands(plan))
         checks.extend(await self._check_openclaw_profiles(repo_path, plan))
+        checks.extend(self._check_hermes_profiles(plan))
+        checks.extend(await self._check_hermes_runtime(repo_path, plan))
         if any(bool(item.metadata.get("requires_origin_remote")) for item in plan):
             checks.append(await self._check_origin_remote(repo_path))
         if any(bool(item.metadata.get("requires_origin_remote")) for item in plan) or any(
@@ -200,6 +202,8 @@ class PreflightRunner:
                 command_names.add(profile.command[0])
             if item.mode == ExecutionMode.OPENCLAW:
                 command_names.add("openclaw")
+            if item.mode == ExecutionMode.HERMES:
+                command_names.add("hermes")
             if item.mode == ExecutionMode.GITHUB:
                 command_names.add("gh")
 
@@ -359,6 +363,414 @@ class PreflightRunner:
                     )
                 )
         return checks
+
+    def _check_hermes_profiles(self, plan: list[WorkItem]) -> list[PreflightCheck]:
+        profile_map = {
+            item.profile: self.config.profiles[item.profile]
+            for item in plan
+            if item.mode == ExecutionMode.HERMES
+        }
+        if not profile_map or shutil.which("hermes") is None:
+            return []
+
+        hermes_home = os.path.expanduser("~/.hermes")
+        config_path = os.path.join(hermes_home, "config.yaml")
+        env_path = os.path.join(hermes_home, ".env")
+        auth_json_path = os.path.join(hermes_home, "auth.json")
+        anthropic_oauth_path = os.path.join(hermes_home, ".anthropic_oauth.json")
+
+        checks: list[PreflightCheck] = []
+        config_data: dict[str, object] = {}
+        if os.path.exists(config_path):
+            try:
+                loaded = _load_yaml(config_path)
+                if isinstance(loaded, dict):
+                    config_data = loaded
+            except Exception as error:
+                status = CheckStatus.WARNING if self.config.runtime.dry_run else CheckStatus.FAILED
+                checks.append(
+                    PreflightCheck(
+                        name="hermes_config",
+                        status=status,
+                        message=f"Hermes config could not be parsed: {error}",
+                        details={"config_path": config_path},
+                    )
+                )
+                return checks
+
+        env_values = self._load_env_file_values(env_path)
+        model_config = config_data.get("model", {})
+        if not isinstance(model_config, dict):
+            model_config = {}
+
+        default_provider = str(model_config.get("provider", "")).strip()
+        default_base_url = str(model_config.get("base_url", "")).strip()
+        default_model = str(model_config.get("default") or model_config.get("model") or "").strip()
+        default_api_key = str(model_config.get("api_key", "")).strip()
+        auth_json_exists = os.path.exists(auth_json_path)
+        anthropic_oauth_exists = os.path.exists(anthropic_oauth_path)
+
+        for profile_name, profile in profile_map.items():
+            effective_provider = profile.hermes_provider.strip() or default_provider or "auto"
+            effective_base_url = default_base_url
+            effective_model = profile.hermes_model.strip() or default_model
+            effective_api_key = default_api_key
+            ready, reason, details = self._hermes_provider_ready(
+                effective_provider,
+                effective_base_url,
+                effective_api_key,
+                env_values,
+                auth_json_exists,
+                anthropic_oauth_exists,
+            )
+            status = CheckStatus.PASSED if ready else (CheckStatus.WARNING if self.config.runtime.dry_run else CheckStatus.FAILED)
+            if ready:
+                message = (
+                    f"Hermes profile `{profile_name}` has a usable inference provider path ({details['provider']})."
+                )
+            else:
+                message = (
+                    f"Hermes profile `{profile_name}` has no ready inference provider. {reason} "
+                    "Run `hermes model` or `hermes auth`, or add the required API key to `~/.hermes/.env`."
+                )
+            details.update(
+                {
+                    "config_path": config_path,
+                    "env_path": env_path,
+                    "auth_json_exists": auth_json_exists,
+                    "anthropic_oauth_exists": anthropic_oauth_exists,
+                }
+            )
+            checks.append(
+                PreflightCheck(
+                    name=f"hermes_provider:{profile_name}",
+                    status=status,
+                    message=message,
+                    details=details,
+                )
+            )
+            if (
+                ready
+                and effective_provider.strip() in {"custom", "main", "lmstudio", "ollama", "vllm", "llamacpp"}
+                and profile.hermes_toolsets
+            ):
+                probe_ok, probe_reason = self._probe_custom_openai_tool_calls(
+                    effective_base_url,
+                    effective_api_key or env_values.get("OPENAI_API_KEY", ""),
+                    effective_model,
+                )
+                probe_status = CheckStatus.PASSED if probe_ok else CheckStatus.WARNING
+                probe_message = (
+                    f"Hermes profile `{profile_name}` custom endpoint supports tool calls."
+                    if probe_ok
+                    else (
+                        f"Hermes profile `{profile_name}` custom endpoint failed the direct tool-call probe: {probe_reason}. "
+                        "Keeping this as a warning because the Hermes runtime probe is authoritative for live supervision/recording runs."
+                    )
+                )
+                checks.append(
+                    PreflightCheck(
+                        name=f"hermes_tool_calling:{profile_name}",
+                        status=probe_status,
+                        message=probe_message,
+                        details={
+                            "provider": effective_provider,
+                            "base_url": effective_base_url,
+                            "model": effective_model,
+                            "toolsets": list(profile.hermes_toolsets),
+                        },
+                    )
+                )
+        return checks
+
+    async def _check_hermes_runtime(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
+        if self.config.runtime.dry_run:
+            return []
+
+        profile_map = {
+            item.profile: self.config.profiles[item.profile]
+            for item in plan
+            if item.mode == ExecutionMode.HERMES and self.config.profiles[item.profile].hermes_toolsets
+        }
+        if not profile_map or shutil.which("hermes") is None:
+            return []
+
+        probe_file = os.path.join(repo_path, "AGENTS.md")
+        if not os.path.exists(probe_file):
+            probe_file = os.path.join(repo_path, "config_v2.yaml")
+        if not os.path.exists(probe_file):
+            return [
+                PreflightCheck(
+                    name="hermes_runtime",
+                    status=CheckStatus.WARNING,
+                    message="Hermes runtime probe skipped because no probe file was found in the repository.",
+                    details={"repo_path": repo_path},
+                )
+            ]
+
+        checks: list[PreflightCheck] = []
+        for profile_name, profile in profile_map.items():
+            prompt = "\n".join(
+                [
+                    "Read the target file with Hermes tools before answering.",
+                    f"Target file: {probe_file}",
+                    "Then reply with exactly:",
+                    "OPENCLAW_STATUS: ready",
+                ]
+            )
+            command = [
+                "hermes",
+                "chat",
+                "-q",
+                prompt,
+                "-Q",
+                "--source",
+                profile.hermes_source.strip() or "tool",
+            ]
+            if profile.hermes_provider.strip():
+                command.extend(["--provider", profile.hermes_provider.strip()])
+            if profile.hermes_model.strip():
+                command.extend(["--model", profile.hermes_model.strip()])
+            toolsets = ",".join(item.strip() for item in profile.hermes_toolsets if item.strip())
+            if toolsets:
+                command.extend(["--toolsets", toolsets])
+            skills = ",".join(item.strip() for item in profile.hermes_skills if item.strip())
+            if skills:
+                command.extend(["--skills", skills])
+            max_turns = profile.hermes_max_turns if profile.hermes_max_turns > 0 else 8
+            command.extend(["--max-turns", str(min(max_turns, 8))])
+            if profile.hermes_yolo:
+                command.append("--yolo")
+
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=repo_path,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=45)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.communicate()
+                checks.append(
+                    PreflightCheck(
+                        name=f"hermes_runtime:{profile_name}",
+                        status=CheckStatus.FAILED,
+                        message="Hermes runtime probe timed out while trying to complete a simple read-only tool task.",
+                        details={"command": command, "probe_file": probe_file},
+                    )
+                )
+                continue
+
+            output = stdout.decode("utf-8", errors="replace").strip()
+            error_output = stderr.decode("utf-8", errors="replace").strip()
+            if process.returncode == 0 and "OPENCLAW_STATUS: ready" in output:
+                checks.append(
+                    PreflightCheck(
+                        name=f"hermes_runtime:{profile_name}",
+                        status=CheckStatus.PASSED,
+                        message="Hermes runtime probe succeeded on a simple read-only tool task.",
+                        details={"probe_file": probe_file},
+                    )
+                )
+                continue
+
+            details = {
+                "probe_file": probe_file,
+                "command": command,
+                "exit_code": process.returncode,
+            }
+            if output:
+                details["output"] = output.splitlines()[-4:]
+            if error_output:
+                details["stderr"] = error_output.splitlines()[-4:]
+            output_lines = [line.strip() for line in output.splitlines() if line.strip()]
+            non_session_output_lines = [
+                line for line in output_lines if not line.lower().startswith("session_id:")
+            ]
+            message = "Hermes runtime probe failed on a simple read-only tool task."
+            if error_output:
+                message = f"{message} {error_output.splitlines()[-1]}"
+            elif non_session_output_lines:
+                message = f"{message} {non_session_output_lines[-1]}"
+            checks.append(
+                PreflightCheck(
+                    name=f"hermes_runtime:{profile_name}",
+                    status=CheckStatus.FAILED,
+                    message=message,
+                    details=details,
+                )
+            )
+
+        return checks
+
+    @staticmethod
+    def _load_env_file_values(path: str) -> dict[str, str]:
+        values = dict(os.environ)
+        if not os.path.exists(path):
+            return values
+
+        with open(path, "r", encoding="utf-8") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, value = line.split("=", 1)
+                key = key.strip()
+                if not key or key in values:
+                    continue
+                values[key] = value.strip().strip('"').strip("'")
+        return values
+
+    @staticmethod
+    def _hermes_provider_ready(
+        provider: str,
+        base_url: str,
+        api_key: str,
+        env_values: dict[str, str],
+        auth_json_exists: bool,
+        anthropic_oauth_exists: bool,
+    ) -> tuple[bool, str, dict[str, object]]:
+        normalized_provider = provider.strip() or "auto"
+        supported_key_groups = {
+            "openrouter": ["OPENROUTER_API_KEY", "OPENAI_API_KEY"],
+            "anthropic": ["ANTHROPIC_API_KEY"],
+            "copilot": ["GITHUB_TOKEN"],
+            "gemini": ["GOOGLE_API_KEY", "GEMINI_API_KEY"],
+            "huggingface": ["HF_TOKEN"],
+            "zai": ["GLM_API_KEY"],
+            "kimi-coding": ["KIMI_API_KEY"],
+            "kimi-coding-cn": ["KIMI_API_KEY"],
+            "minimax": ["MINIMAX_API_KEY"],
+            "minimax-cn": ["MINIMAX_CN_API_KEY"],
+            "xiaomi": ["XIAOMI_API_KEY"],
+            "arcee": ["ARCEEAI_API_KEY"],
+            "ollama-cloud": ["OLLAMA_API_KEY"],
+            "kilocode": ["KILOCODE_API_KEY"],
+            "nous": ["NOUS_API_KEY"],
+            "openai-codex": ["OPENAI_API_KEY"],
+        }
+
+        def present(keys: list[str]) -> list[str]:
+            return [key for key in keys if env_values.get(key, "").strip()]
+
+        details: dict[str, object] = {"provider": normalized_provider}
+        if api_key.strip():
+            details["credential_source"] = "config_api_key"
+            return True, "", details
+
+        if normalized_provider in {"custom", "lmstudio", "ollama", "vllm", "llamacpp"}:
+            if base_url.strip():
+                details["credential_source"] = "custom_base_url"
+                details["base_url"] = base_url
+                return True, "", details
+            return False, "No custom base_url is configured for the local OpenAI-compatible endpoint.", details
+
+        if normalized_provider == "anthropic":
+            if anthropic_oauth_exists or auth_json_exists:
+                details["credential_source"] = "oauth_store"
+                return True, "", details
+            found = present(supported_key_groups["anthropic"])
+            if found:
+                details["credential_source"] = "env"
+                details["env_keys"] = found
+                return True, "", details
+            return False, "Anthropic provider requires OAuth credentials or ANTHROPIC_API_KEY.", details
+
+        if normalized_provider == "openai-codex":
+            if auth_json_exists:
+                details["credential_source"] = "auth_store"
+                return True, "", details
+            found = present(supported_key_groups["openai-codex"])
+            if found:
+                details["credential_source"] = "env"
+                details["env_keys"] = found
+                return True, "", details
+            return False, "OpenAI Codex provider requires `hermes auth` or an OPENAI_API_KEY.", details
+
+        if normalized_provider in supported_key_groups:
+            found = present(supported_key_groups[normalized_provider])
+            if found:
+                details["credential_source"] = "env"
+                details["env_keys"] = found
+                return True, "", details
+            return (
+                False,
+                f"{normalized_provider} provider is selected but no matching credential was found.",
+                details,
+            )
+
+        auto_keys: list[str] = []
+        for keys in supported_key_groups.values():
+            for key in keys:
+                if key not in auto_keys:
+                    auto_keys.append(key)
+        found = present(auto_keys)
+        if found:
+            details["credential_source"] = "env"
+            details["env_keys"] = found
+            return True, "", details
+        if auth_json_exists or anthropic_oauth_exists:
+            details["credential_source"] = "auth_store"
+            return True, "", details
+        if base_url.strip() and "openrouter.ai" not in base_url:
+            details["credential_source"] = "custom_base_url"
+            details["base_url"] = base_url
+            return True, "", details
+        return False, "Auto provider could not find any usable Hermes credentials or local endpoint.", details
+
+    @staticmethod
+    def _probe_custom_openai_tool_calls(
+        base_url: str,
+        api_key: str,
+        model: str,
+    ) -> tuple[bool, str]:
+        if not base_url.strip():
+            return False, "No custom base_url is configured."
+        if not model.strip():
+            return False, "No model is configured for the custom Hermes endpoint."
+
+        try:
+            from openai import OpenAI
+        except ModuleNotFoundError:
+            return False, "The `openai` Python package is unavailable for endpoint probing."
+
+        try:
+            client = OpenAI(base_url=base_url, api_key=api_key or "dummy")
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {
+                        "role": "user",
+                        "content": "Call the ping tool with value 'ok' and stop.",
+                    }
+                ],
+                tools=[
+                    {
+                        "type": "function",
+                        "function": {
+                            "name": "ping",
+                            "description": "Return a ping payload.",
+                            "parameters": {
+                                "type": "object",
+                                "properties": {"value": {"type": "string"}},
+                                "required": ["value"],
+                            },
+                        },
+                    }
+                ],
+                tool_choice={"type": "function", "function": {"name": "ping"}},
+                max_tokens=64,
+            )
+        except Exception as error:
+            return False, str(error)
+
+        message = response.choices[0].message if response.choices else None
+        tool_calls = getattr(message, "tool_calls", None)
+        if tool_calls:
+            return True, ""
+        return False, "The endpoint returned a response without any tool calls."
 
     @staticmethod
     def _is_within_repo(workspace_path: str, repo_path: str) -> bool:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -75,6 +75,54 @@ class ConfigLoaderTests(unittest.TestCase):
         self.assertEqual(config.assignments["triage_local"].required_capabilities, ["triage"])
         self.assertEqual(config.pipelines["demo"][0].assignment, "triage_local")
 
+    def test_load_app_config_reads_hermes_profile_fields(self) -> None:
+        content = textwrap.dedent(
+            """
+            profiles:
+              hermes_local:
+                agent: hermes
+                mode: hermes
+                hermes_provider: copilot
+                hermes_model: gpt-5
+                hermes_toolsets: [file, terminal]
+                hermes_skills: [repo-review]
+                hermes_source: tool
+                hermes_max_turns: 24
+                hermes_yolo: true
+            managed_agents:
+              hermes_supervisor:
+                kind: hermes
+                profile: hermes_local
+                capabilities: [triage, review]
+            assignments:
+              triage_local:
+                agent: hermes_supervisor
+            pipelines:
+              demo:
+                - id: triage
+                  title: Triage
+                  assignment: triage_local
+                  prompt_template: test
+            """
+        ).strip()
+
+        with tempfile.NamedTemporaryFile("w+", suffix=".yaml", encoding="utf-8") as handle:
+            handle.write(content)
+            handle.flush()
+            config = load_app_config(handle.name)
+
+        profile = config.profiles["hermes_local"]
+        self.assertEqual(profile.agent, AgentType.HERMES)
+        self.assertEqual(profile.mode, ExecutionMode.HERMES)
+        self.assertEqual(profile.hermes_provider, "copilot")
+        self.assertEqual(profile.hermes_model, "gpt-5")
+        self.assertEqual(profile.hermes_toolsets, ["file", "terminal"])
+        self.assertEqual(profile.hermes_skills, ["repo-review"])
+        self.assertEqual(profile.hermes_source, "tool")
+        self.assertEqual(profile.hermes_max_turns, 24)
+        self.assertTrue(profile.hermes_yolo)
+        self.assertEqual(config.managed_agents["hermes_supervisor"].kind, AgentType.HERMES)
+
     def test_load_app_config_reads_cli_unset_env_fields(self) -> None:
         content = textwrap.dedent(
             """

--- a/tests/test_hermes_executor.py
+++ b/tests/test_hermes_executor.py
@@ -1,0 +1,203 @@
+import asyncio
+import unittest
+from unittest import mock
+
+from openclaw_v2.config import ProfileConfig, load_app_config
+from openclaw_v2.executors.hermes import HermesExecutor
+from openclaw_v2.models import AgentType, ExecutionContext, ExecutionMode, TaskStatus, WorkItem
+
+
+class _FakeProcess:
+    def __init__(self, returncode: int = 0, stdout: str = "", stderr: str = "", delay: float = 0.0) -> None:
+        self.returncode = returncode
+        self._stdout = stdout.encode("utf-8")
+        self._stderr = stderr.encode("utf-8")
+        self._delay = delay
+
+    async def communicate(self):
+        if self._delay:
+            await asyncio.sleep(self._delay)
+        return self._stdout, self._stderr
+
+
+class HermesExecutorTests(unittest.TestCase):
+    def test_prepare_prompt_includes_repo_handoff(self) -> None:
+        context = ExecutionContext(
+            run_id="run-1",
+            user_request="summarize repo",
+            repo_path="/tmp/repo",
+            dry_run=False,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+        work_item = WorkItem(
+            id="triage",
+            title="Triage",
+            profile="hermes_local",
+            agent=AgentType.HERMES,
+            mode=ExecutionMode.HERMES,
+            prompt_template="",
+            workspace_path="/tmp/repo-worktree",
+        )
+
+        prompt = HermesExecutor._prepare_prompt("hello world", context, work_item)
+
+        self.assertIn("Hermes repository handoff:", prompt)
+        self.assertIn("Primary repository path: /tmp/repo-worktree", prompt)
+        self.assertIn("/tmp/repo-worktree/AGENTS.md", prompt)
+        self.assertTrue(prompt.endswith("hello world"))
+
+    def test_build_command_uses_configured_provider_toolsets_and_skills(self) -> None:
+        profile = ProfileConfig(
+            name="hermes_local",
+            agent=AgentType.HERMES,
+            mode=ExecutionMode.HERMES,
+            hermes_provider="copilot",
+            hermes_model="gpt-5",
+            hermes_toolsets=["file", "terminal"],
+            hermes_skills=["repo-review"],
+            hermes_source="tool",
+            hermes_max_turns=24,
+            hermes_yolo=True,
+        )
+
+        command = HermesExecutor._build_command(profile, "hello world")
+
+        self.assertEqual(
+            command,
+            [
+                "hermes",
+                "chat",
+                "-q",
+                "hello world",
+                "-Q",
+                "--source",
+                "tool",
+                "--provider",
+                "copilot",
+                "--model",
+                "gpt-5",
+                "--toolsets",
+                "file,terminal",
+                "--skills",
+                "repo-review",
+                "--max-turns",
+                "24",
+                "--yolo",
+            ],
+        )
+
+    def test_strip_session_footer_extracts_session_id(self) -> None:
+        output = "\n".join(
+            [
+                "OPENCLAW_STATUS: ready",
+                "1. all good",
+                "",
+                "Resume this session with:",
+                "  hermes --resume 20260416_123456_abcd1234",
+                "",
+                "Session: 20260416_123456_abcd1234",
+                "Duration: 4s",
+                "Messages: 3 (1 user, 2 tool calls)",
+            ]
+        )
+
+        cleaned, session_id = HermesExecutor._strip_session_footer(output)
+
+        self.assertEqual(session_id, "20260416_123456_abcd1234")
+        self.assertEqual(cleaned, "OPENCLAW_STATUS: ready\n1. all good")
+
+
+class HermesExecutorExecutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_execute_dry_run_preserves_artifacts(self) -> None:
+        executor = HermesExecutor(load_app_config("config_v2.yaml"))
+        context = ExecutionContext(
+            run_id="run-1",
+            user_request="summarize repo",
+            repo_path="/tmp/repo",
+            dry_run=True,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+        work_item = WorkItem(
+            id="record_summary",
+            title="Record collaboration summary with Hermes",
+            profile="hermes_local",
+            agent=AgentType.HERMES,
+            mode=ExecutionMode.HERMES,
+            prompt_template="hello",
+            workspace_path="/tmp/repo",
+        )
+        profile = ProfileConfig(
+            name="hermes_local",
+            agent=AgentType.HERMES,
+            mode=ExecutionMode.HERMES,
+            hermes_provider="auto",
+            hermes_toolsets=["file", "terminal"],
+            hermes_source="tool",
+            hermes_max_turns=40,
+        )
+
+        result = await executor.execute(work_item, profile, context, "hello")
+
+        self.assertEqual(result.status, TaskStatus.SUCCEEDED)
+        self.assertEqual(result.artifacts["workspace_path"], "/tmp/repo")
+        self.assertEqual(result.artifacts["hermes_source"], "tool")
+        self.assertEqual(result.artifacts["hermes_toolsets"], ["file", "terminal"])
+        self.assertIn("Hermes repository handoff:", result.output)
+
+    async def test_execute_parses_control_markers_and_session_footer(self) -> None:
+        executor = HermesExecutor(load_app_config("config_v2.yaml"))
+        context = ExecutionContext(
+            run_id="run-1",
+            user_request="review branch",
+            repo_path="/tmp/repo",
+            dry_run=False,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+        work_item = WorkItem(
+            id="review",
+            title="Review implementation before publish with Hermes",
+            profile="hermes_local",
+            agent=AgentType.HERMES,
+            mode=ExecutionMode.HERMES,
+            prompt_template="hello",
+            workspace_path="/tmp/repo",
+        )
+        profile = ProfileConfig(
+            name="hermes_local",
+            agent=AgentType.HERMES,
+            mode=ExecutionMode.HERMES,
+            hermes_provider="auto",
+            hermes_source="tool",
+        )
+        hermes_output = "\n".join(
+            [
+                "OPENCLAW_STATUS: blocked",
+                "OPENCLAW_BLOCK_REASON: 缺少实现产物，无法审阅",
+                "",
+                "当前缺少实现分支。",
+                "",
+                "Session: 20260416_123456_abcd1234",
+                "Duration: 3s",
+                "Messages: 2 (1 user, 1 tool call)",
+            ]
+        )
+        process = _FakeProcess(stdout=hermes_output)
+
+        with mock.patch(
+            "openclaw_v2.executors.hermes.asyncio.create_subprocess_exec",
+            new=mock.AsyncMock(return_value=process),
+        ):
+            result = await executor.execute(work_item, profile, context, "hello")
+
+        self.assertEqual(result.status, TaskStatus.BLOCKED)
+        self.assertEqual(result.artifacts["blocked_reason"], "缺少实现产物，无法审阅")
+        self.assertEqual(result.artifacts["hermes_session_id"], "20260416_123456_abcd1234")
+        self.assertEqual(result.output, "当前缺少实现分支。")
+        self.assertIn("Hermes task Review implementation before publish with Hermes blocked", result.summary)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -106,6 +106,37 @@ class PipelineConfigTests(unittest.TestCase):
         self.assertEqual(work_items["implement"].profile, "openclaw_local")
         self.assertEqual(work_items["implement"].mode, ExecutionMode.OPENCLAW)
 
+    def test_hermes_supervised_pipeline_uses_hermes_for_supervision_and_recording(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "mission_control_hermes_supervised"
+        planner = PipelinePlanner(config)
+
+        plan = planner.build_plan()
+        work_items = {item.id: item for item in plan}
+
+        self.assertEqual(work_items["triage"].profile, "hermes_local")
+        self.assertEqual(work_items["triage"].assignment, "triage_hermes")
+        self.assertEqual(work_items["triage"].managed_agent, "hermes_supervisor")
+        self.assertEqual(work_items["triage"].mode, ExecutionMode.HERMES)
+        self.assertEqual(work_items["implement"].mode, ExecutionMode.CLI)
+        self.assertEqual(work_items["review"].profile, "hermes_local")
+        self.assertEqual(work_items["review"].assignment, "review_hermes")
+        self.assertEqual(work_items["review"].managed_agent, "hermes_supervisor")
+        self.assertEqual(work_items["review"].mode, ExecutionMode.HERMES)
+        self.assertEqual(work_items["record_summary"].profile, "hermes_local")
+        self.assertEqual(work_items["record_summary"].assignment, "record_summary_hermes")
+        self.assertEqual(work_items["record_summary"].managed_agent, "hermes_scribe")
+        self.assertEqual(work_items["record_summary"].mode, ExecutionMode.HERMES)
+        self.assertEqual(sorted(work_items["record_summary"].depends_on), ["publish_branch", "review", "sync_issue"])
+        self.assertEqual(
+            sorted(work_items["update_issue"].depends_on),
+            ["publish_branch", "record_summary", "review", "sync_issue"],
+        )
+        self.assertEqual(
+            sorted(work_items["draft_pr"].depends_on),
+            ["publish_branch", "record_summary", "review", "sync_issue", "update_issue"],
+        )
+
     def test_github_bridge_smoke_pipeline_only_contains_review_workflow_steps(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.pipeline = "github_bridge_smoke"
@@ -132,6 +163,7 @@ class PipelineConfigTests(unittest.TestCase):
             "hybrid_default",
             "mission_control_openclaw_triage",
             "mission_control_openclaw_default",
+            "mission_control_hermes_supervised",
             "github_bridge_smoke",
         ]:
             config.runtime.pipeline = pipeline_name

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -177,6 +177,226 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("Available local agents: main, openclaw-control-ext.", checks[0].message)
         self.assertEqual(checks[0].details["available_agent_ids"], ["main", "openclaw-control-ext"])
 
+    async def test_required_commands_include_hermes_for_hermes_steps(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        def fake_which(command: str) -> str | None:
+            if command in {"git", "hermes"}:
+                return f"/usr/bin/{command}"
+            return None
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", side_effect=fake_which):
+            checks = await runner._check_required_commands(plan)
+
+        names = {check.name: check for check in checks}
+        self.assertEqual(names["command:git"].status, CheckStatus.PASSED)
+        self.assertEqual(names["command:hermes"].status, CheckStatus.PASSED)
+
+    def test_hermes_provider_preflight_warns_when_no_credentials_exist(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            with open(os.path.join(hermes_home, "config.yaml"), "w", encoding="utf-8") as handle:
+                handle.write("model:\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n")
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.WARNING)
+        self.assertIn("no ready inference provider", checks[0].message)
+
+    def test_hermes_provider_preflight_passes_with_env_api_key(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            with open(os.path.join(hermes_home, "config.yaml"), "w", encoding="utf-8") as handle:
+                handle.write("model:\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n")
+            with open(os.path.join(hermes_home, ".env"), "w", encoding="utf-8") as handle:
+                handle.write("OPENROUTER_API_KEY=test-key\n")
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertIn("usable inference provider path", checks[0].message)
+
+    def test_hermes_provider_preflight_checks_tool_call_support_for_custom_endpoint(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            with open(os.path.join(hermes_home, "config.yaml"), "w", encoding="utf-8") as handle:
+                handle.write(
+                    "model:\n"
+                    "  provider: custom\n"
+                    "  default: gpt-5.4\n"
+                    "  base_url: http://127.0.0.1:1234/v1\n"
+                )
+            with open(os.path.join(hermes_home, ".env"), "w", encoding="utf-8") as handle:
+                handle.write("OPENAI_API_KEY=test-key\n")
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    with mock.patch.object(
+                        PreflightRunner,
+                        "_probe_custom_openai_tool_calls",
+                        return_value=(False, "unexpected EOF"),
+                    ):
+                        checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertEqual(checks[1].status, CheckStatus.WARNING)
+        self.assertIn("failed the direct tool-call probe", checks[1].message)
+
+    def test_hermes_provider_preflight_passes_tool_call_probe(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            with open(os.path.join(hermes_home, "config.yaml"), "w", encoding="utf-8") as handle:
+                handle.write(
+                    "model:\n"
+                    "  provider: custom\n"
+                    "  default: gpt-5.4\n"
+                    "  base_url: http://127.0.0.1:1234/v1\n"
+                )
+            with open(os.path.join(hermes_home, ".env"), "w", encoding="utf-8") as handle:
+                handle.write("OPENAI_API_KEY=test-key\n")
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    with mock.patch.object(
+                        PreflightRunner,
+                        "_probe_custom_openai_tool_calls",
+                        return_value=(True, ""),
+                    ):
+                        checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertEqual(checks[1].status, CheckStatus.PASSED)
+        self.assertIn("supports tool calls", checks[1].message)
+
+    async def test_hermes_runtime_probe_passes_when_ready_marker_is_returned(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            with open(os.path.join(repo_path, "AGENTS.md"), "w", encoding="utf-8") as handle:
+                handle.write("# test\n")
+
+            with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                with mock.patch(
+                    "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                    new=mock.AsyncMock(return_value=_FakeProcess(0, "OPENCLAW_STATUS: ready\n")),
+                ):
+                    checks = await runner._check_hermes_runtime(repo_path, plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertIn("runtime probe succeeded", checks[0].message)
+
+    async def test_hermes_runtime_probe_fails_when_tool_run_errors(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            with open(os.path.join(repo_path, "AGENTS.md"), "w", encoding="utf-8") as handle:
+                handle.write("# test\n")
+
+            with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                with mock.patch(
+                    "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                    new=mock.AsyncMock(return_value=_FakeProcess(1, "API call failed after 3 retries: Connection error.\n")),
+                ):
+                    checks = await runner._check_hermes_runtime(repo_path, plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("runtime probe failed", checks[0].message)
+
     def test_github_workflow_preflight_fails_when_file_is_missing_in_live_mode(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.dry_run = False


### PR DESCRIPTION
## Summary
- add a local Hermes executor for supervision and recorder flows
- add Hermes managed agents, assignments, and the `mission_control_hermes_supervised` pipeline
- extend preflight and tests to cover Hermes provider/runtime readiness and recorder wiring

## Validation
- `python3 -m unittest discover -s tests`
- `python3 main_v2.py --doctor-config`
- `python3 main_v2.py --live --pipeline mission_control_hermes_supervised --preflight-only --steps triage,review,record_summary --request "请确认这个仓库是否以 main_v2.py + openclaw_v2 为主线，并给出继续实施的任务拆分。"`
- `python3 main_v2.py --live --pipeline mission_control_hermes_supervised --steps triage --request "请确认这个仓库是否以 main_v2.py + openclaw_v2 为主线，并给出继续实施的任务拆分。"`
- GitHub review workflow on current head `d0b9898`: https://github.com/crused-fall/Openclaw-AIagent-control/actions/runs/25115155888

## Notes
- local validation used a separate Hermes runtime fix branch (`codex/fix-hermes-openai-client-lifecycle`) to avoid request-client reuse after tool calls
- the Hermes runtime probe is treated as authoritative for live runs; direct custom endpoint tool-call probing stays diagnostic

## Review state
- This PR is ready for human review.
