### PR TITLE
Add doctor-config CLI regression test

### DIFF
--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -369,6 +369,21 @@ class MainV2PolicyTests(unittest.TestCase):
 
 
 class MainV2WebModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_main_runs_doctor_config_and_exits_without_prompting(self) -> None:
+        with (
+            mock.patch.object(sys, "argv", ["main_v2.py", "--doctor-config"]),
+            mock.patch("builtins.input", side_effect=AssertionError("doctor-config should not prompt")),
+            io.StringIO() as buffer,
+            redirect_stdout(buffer),
+        ):
+            await main()
+            output = buffer.getvalue()
+
+        self.assertIn("Preflight:", output)
+        self.assertIn("runtime:github_retry_attempts", output)
+        self.assertIn("pipeline:mission_control_default:dispatch_review", output)
+        self.assertNotIn("OpenClaw v2 已启动", output)
+
     async def test_main_starts_web_server_with_expected_args(self) -> None:
         class FakeOrchestrator:
             def __init__(self, config) -> None:


### PR DESCRIPTION
## Summary
- add a CLI regression test that exercises `python3 main_v2.py --doctor-config`
- verify the command prints preflight diagnostics and exits without prompting

## Validation
- `python3 -m unittest tests.test_main_v2`
- `python3 -m unittest tests.test_preflight tests.test_config_diagnostics tests.test_pipeline_config`
- `python3 -m unittest discover -s tests`
- GitHub review workflow on current head `17f517f`: https://github.com/crused-fall/Openclaw-AIagent-control/actions/runs/25117544781

## Notes
- this keeps the doctor-config health check pinned to the expected CLI behavior as the mainline continues to evolve
