### PR TITLE
Harden web race handling

### DIFF
--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -94,6 +94,7 @@
 - Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
+- Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -93,6 +93,7 @@
 - Web UI 的 cleanup artifact 删除在真实 OSError 下会返回 failure 记录，不再伪装成 skipped
 - Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
+- Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -99,6 +99,7 @@
 - Worktree cleanup 现在会把 `git worktree remove` 在 workspace 已经消失时的错误当成可恢复竞态，并把后续 `git branch -D` 在分支已不存在时的错误也视作可恢复，不再因为 cleanup 对象被别的流程先清掉就中断整段 cleanup
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
 - Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
+- Hermes runtime probe 现在也会把 probe 文件在选中后、读出前消失收敛成 warning，不再把 Hermes 前置检查拖成异常
 - 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败；判定依据是文件当前是否仍然存在，而不是 Ruby stderr 文本
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -96,6 +96,7 @@
 - Web UI 的 cleanup artifact 删除在真实 OSError 下会返回 failure 记录，不再伪装成 skipped
 - Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
+- Worktree cleanup 现在会把 `git worktree remove` 在 workspace 已经消失时的错误当成可恢复竞态，继续执行后续分支删除，不再因为工作区先消失就中断整段 cleanup
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
 - Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
 - 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败；判定依据是文件当前是否仍然存在，而不是 Ruby stderr 文本

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -94,7 +94,7 @@
 - Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
-- Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常
+- Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -95,6 +95,7 @@
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
 - Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
+- 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -21,6 +21,7 @@
 - 支持 `--list-managed-agents`、`--doctor-config`、`--diagnose-plan`
 - `--doctor-config` 已有 CLI 回归测试并合并到 main，锁定配置诊断路径不会误进入交互模式
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
+- CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失或变成不可读的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -20,6 +20,7 @@
 - 支持 `--steps`、`--request`、`--live`、`--preflight-only`
 - 支持 `--list-managed-agents`、`--doctor-config`、`--diagnose-plan`
 - `--doctor-config` 已有 CLI 回归测试并合并到 main，锁定配置诊断路径不会误进入交互模式
+- CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 
@@ -95,7 +96,7 @@
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
 - Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
-- 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败
+- 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败；判定依据是文件当前是否仍然存在，而不是 Ruby stderr 文本
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -91,6 +91,8 @@
 - Web UI 的 cleanup artifact 删除现在也会把 run 目录在删除时消失收敛成已缺失，不再把 housekeeping 因竞态拖成 `500`
 - Web UI 的 artifact file 预览在 stat 消失时会保留原始大小，不再把截断文件误报成 limit 大小
 - Web UI 的 cleanup artifact 删除在真实 OSError 下会返回 failure 记录，不再伪装成 skipped
+- Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
+- Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -89,6 +89,8 @@
 - Web UI 的 recent runs 现在也会把 `preflight.json` 在读取时消失收敛成缺失预检，避免首页因为预检竞态冒成 `500`
 - Web UI 的 cleanup manifest 读取现在也会跳过在读取时消失的 workspace manifest，避免 housekeeping 因竞态冒成 `500`
 - Web UI 的 cleanup artifact 删除现在也会把 run 目录在删除时消失收敛成已缺失，不再把 housekeeping 因竞态拖成 `500`
+- Web UI 的 artifact file 预览在 stat 消失时会保留原始大小，不再把截断文件误报成 limit 大小
+- Web UI 的 cleanup artifact 删除在真实 OSError 下会返回 failure 记录，不再伪装成 skipped
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -84,6 +84,7 @@
 - Web UI 的 health snapshot 现在会对 `openclaw health --json` 的 `channelOrder` / `channels` / `agents` / `defaultAgentId` 做保守解析，避免健康页被坏 payload 拖成 `500`
 - Web UI 的 recent runs / cleanup manifest 读取现在也会跳过坏字节输入，避免 `summary.json` / workspace manifest 的编码错误拖垮页面
 - Web UI 的 recent runs / history 读取现在能容忍 `summary.json` 在扫描或读取间消失，避免竞争条件把页面拖成 `500`
+- Web UI 的 history / cleanup / prune 现在会复用请求内已解析的 config，不再在后台线程里二次打开配置文件；这样 config 在请求中途消失时，不会把已经开始的历史读取或清理拖成 `500`
 - Web UI 的 history 文件列表和单文件读取现在也会容忍文件在 size/stat 阶段消失，避免 artifact browser 的竞态把页面拖成 `500`
 - Web UI 的 recent runs / housekeeping prune 现在也会跳过在排序阶段消失的 run 目录，避免目录级竞态把页面拖成 `500`
 - Web UI 的 history 详情页现在也会把 run 目录在更新时间戳阶段消失收敛成 404，避免目录级竞态冒成 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -88,6 +88,7 @@
 - Web UI 的 history 详情页现在也会把 run 目录在更新时间戳阶段消失收敛成 404，避免目录级竞态冒成 `500`
 - Web UI 的 recent runs 现在也会把 `preflight.json` 在读取时消失收敛成缺失预检，避免首页因为预检竞态冒成 `500`
 - Web UI 的 cleanup manifest 读取现在也会跳过在读取时消失的 workspace manifest，避免 housekeeping 因竞态冒成 `500`
+- Web UI 的 cleanup artifact 删除现在也会把 run 目录在删除时消失收敛成已缺失，不再把 housekeeping 因竞态拖成 `500`
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -83,9 +83,15 @@
 - Web UI 的 health snapshot 现在会对 `openclaw health --json` 的 `channelOrder` / `channels` / `agents` / `defaultAgentId` 做保守解析，避免健康页被坏 payload 拖成 `500`
 - Web UI 的 recent runs / cleanup manifest 读取现在也会跳过坏字节输入，避免 `summary.json` / workspace manifest 的编码错误拖垮页面
 - Web UI 的 recent runs / history 读取现在能容忍 `summary.json` 在扫描或读取间消失，避免竞争条件把页面拖成 `500`
+- Web UI 的 history 文件列表和单文件读取现在也会容忍文件在 size/stat 阶段消失，避免 artifact browser 的竞态把页面拖成 `500`
+- Web UI 的 recent runs / housekeeping prune 现在也会跳过在排序阶段消失的 run 目录，避免目录级竞态把页面拖成 `500`
+- Web UI 的 history 详情页现在也会把 run 目录在更新时间戳阶段消失收敛成 404，避免目录级竞态冒成 `500`
+- Web UI 的 recent runs 现在也会把 `preflight.json` 在读取时消失收敛成缺失预检，避免首页因为预检竞态冒成 `500`
+- Web UI 的 cleanup manifest 读取现在也会跳过在读取时消失的 workspace manifest，避免 housekeeping 因竞态冒成 `500`
 - Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`
+- Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报
 - Web API 的任务创建现在会拒绝非布尔的 `live`，避免字符串值误入 live 模式
 - Web API 的任务创建现在会严格校验 `steps` 形状，避免非字符串列表项进入后台执行
 - Web API 的任务创建现在会在入队前拒绝空请求文本和未知 step id，避免先返回 `202` 再异步失败

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -21,7 +21,7 @@
 - 支持 `--list-managed-agents`、`--doctor-config`、`--diagnose-plan`
 - `--doctor-config` 已有 CLI 回归测试并合并到 main，锁定配置诊断路径不会误进入交互模式
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
-- CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失或变成不可读的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
+- CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -96,7 +96,7 @@
 - Web UI 的 cleanup artifact 删除在真实 OSError 下会返回 failure 记录，不再伪装成 skipped
 - Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
 - Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
-- Worktree cleanup 现在会把 `git worktree remove` 在 workspace 已经消失时的错误当成可恢复竞态，继续执行后续分支删除，不再因为工作区先消失就中断整段 cleanup
+- Worktree cleanup 现在会把 `git worktree remove` 在 workspace 已经消失时的错误当成可恢复竞态，并把后续 `git branch -D` 在分支已不存在时的错误也视作可恢复，不再因为 cleanup 对象被别的流程先清掉就中断整段 cleanup
 - Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
 - Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
 - 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败；判定依据是文件当前是否仍然存在，而不是 Ruby stderr 文本

--- a/main_v2.py
+++ b/main_v2.py
@@ -333,8 +333,11 @@ def _print_preflight(artifacts_dir: str) -> None:
     if not os.path.exists(preflight_path):
         return
 
-    with open(preflight_path, "r", encoding="utf-8") as handle:
-        report = json.load(handle)
+    try:
+        with open(preflight_path, "r", encoding="utf-8") as handle:
+            report = json.load(handle)
+    except (FileNotFoundError, OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return
 
     print("\nPreflight:")
     for check in report.get("checks", []):

--- a/main_v2.py
+++ b/main_v2.py
@@ -403,7 +403,10 @@ async def _run_once(
 
 async def main() -> None:
     args = _parse_args()
-    config = load_app_config(args.config)
+    try:
+        config = load_app_config(args.config)
+    except FileNotFoundError as error:
+        raise SystemExit(f"Config file not found: {args.config}") from error
     if args.pipeline:
         config.runtime.pipeline = args.pipeline
     if args.live:

--- a/main_v2.py
+++ b/main_v2.py
@@ -338,6 +338,8 @@ def _print_preflight(artifacts_dir: str) -> None:
             report = json.load(handle)
     except (FileNotFoundError, OSError, json.JSONDecodeError, UnicodeDecodeError):
         return
+    if not isinstance(report, dict):
+        return
 
     print("\nPreflight:")
     for check in report.get("checks", []):

--- a/openclaw_v2/config.py
+++ b/openclaw_v2/config.py
@@ -808,6 +808,8 @@ def _load_yaml(path: str) -> dict[str, Any]:
         ) from error
     except subprocess.CalledProcessError as error:
         message = error.stderr.strip() or error.stdout.strip() or "Unknown YAML parsing error."
+        if "No such file or directory" in message or "Errno::ENOENT" in message:
+            raise FileNotFoundError(path) from error
         raise RuntimeError(f"Failed to parse YAML config {path}: {message}") from error
 
     data = json.loads(result.stdout or "{}")

--- a/openclaw_v2/config.py
+++ b/openclaw_v2/config.py
@@ -808,7 +808,7 @@ def _load_yaml(path: str) -> dict[str, Any]:
         ) from error
     except subprocess.CalledProcessError as error:
         message = error.stderr.strip() or error.stdout.strip() or "Unknown YAML parsing error."
-        if "No such file or directory" in message or "Errno::ENOENT" in message:
+        if not os.path.exists(path):
             raise FileNotFoundError(path) from error
         raise RuntimeError(f"Failed to parse YAML config {path}: {message}") from error
 

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -503,13 +503,22 @@ class PreflightRunner:
         probe_file = os.path.join(repo_path, "AGENTS.md")
         if not os.path.exists(probe_file):
             probe_file = os.path.join(repo_path, "config_v2.yaml")
+            if not os.path.exists(probe_file):
+                return [
+                    PreflightCheck(
+                        name="hermes_runtime",
+                        status=CheckStatus.WARNING,
+                        message="Hermes runtime probe skipped because no probe file was found in the repository.",
+                        details={"repo_path": repo_path},
+                    )
+                ]
         if not os.path.exists(probe_file):
             return [
                 PreflightCheck(
                     name="hermes_runtime",
                     status=CheckStatus.WARNING,
-                    message="Hermes runtime probe skipped because no probe file was found in the repository.",
-                    details={"repo_path": repo_path},
+                    message="Hermes runtime probe skipped because the probe file disappeared before the read could start.",
+                    details={"repo_path": repo_path, "probe_file": probe_file},
                 )
             ]
 

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -386,6 +386,8 @@ class PreflightRunner:
                 loaded = _load_yaml(config_path)
                 if isinstance(loaded, dict):
                     config_data = loaded
+            except (FileNotFoundError, OSError):
+                config_data = {}
             except Exception as error:
                 status = CheckStatus.WARNING if self.config.runtime.dry_run else CheckStatus.FAILED
                 checks.append(

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -389,16 +389,19 @@ class PreflightRunner:
             except (FileNotFoundError, OSError):
                 config_data = {}
             except Exception as error:
-                status = CheckStatus.WARNING if self.config.runtime.dry_run else CheckStatus.FAILED
-                checks.append(
-                    PreflightCheck(
-                        name="hermes_config",
-                        status=status,
-                        message=f"Hermes config could not be parsed: {error}",
-                        details={"config_path": config_path},
+                if not os.path.exists(config_path):
+                    config_data = {}
+                else:
+                    status = CheckStatus.WARNING if self.config.runtime.dry_run else CheckStatus.FAILED
+                    checks.append(
+                        PreflightCheck(
+                            name="hermes_config",
+                            status=status,
+                            message=f"Hermes config could not be parsed: {error}",
+                            details={"config_path": config_path},
+                        )
                     )
-                )
-                return checks
+                    return checks
 
         env_values = self._load_env_file_values(env_path)
         model_config = config_data.get("model", {})

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -611,16 +611,19 @@ class PreflightRunner:
         if not os.path.exists(path):
             return values
 
-        with open(path, "r", encoding="utf-8") as handle:
-            for raw_line in handle:
-                line = raw_line.strip()
-                if not line or line.startswith("#") or "=" not in line:
-                    continue
-                key, value = line.split("=", 1)
-                key = key.strip()
-                if not key or key in values:
-                    continue
-                values[key] = value.strip().strip('"').strip("'")
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
+                    if not line or line.startswith("#") or "=" not in line:
+                        continue
+                    key, value = line.split("=", 1)
+                    key = key.strip()
+                    if not key or key in values:
+                        continue
+                    values[key] = value.strip().strip('"').strip("'")
+        except (FileNotFoundError, OSError):
+            return values
         return values
 
     @staticmethod

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -992,17 +992,36 @@ def _cleanup_run_resources(
                 )
 
     if remove_artifacts and run_dir.exists():
-        shutil.rmtree(run_dir, ignore_errors=False)
-        operations.append(
-            {
-                "type": "artifacts_delete",
-                "path": str(run_dir),
-                "ok": True,
-                "exitCode": 0,
-                "stdout": "",
-                "stderr": "",
-            }
-        )
+        try:
+            shutil.rmtree(run_dir, ignore_errors=False)
+        except FileNotFoundError:
+            operations.append(
+                _cleanup_skip(
+                    "artifacts_delete",
+                    "Run directory is already absent.",
+                    path=str(run_dir),
+                )
+            )
+        except OSError as error:
+            operations.append(
+                _cleanup_skip(
+                    "artifacts_delete",
+                    "Run directory could not be removed.",
+                    path=str(run_dir),
+                    error=str(error),
+                )
+            )
+        else:
+            operations.append(
+                {
+                    "type": "artifacts_delete",
+                    "path": str(run_dir),
+                    "ok": True,
+                    "exitCode": 0,
+                    "stdout": "",
+                    "stderr": "",
+                }
+            )
 
     return {
         "runId": run_dir.name,

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -16,7 +16,7 @@ from typing import Any
 
 from aiohttp import web
 
-from .config import diagnose_app_config, load_app_config, resolve_runtime_path
+from .config import AppConfig, diagnose_app_config, load_app_config, resolve_runtime_path
 from .github_support import normalize_github_repo, resolve_github_repo_from_origin
 from .models import TaskStatus
 from .orchestrator import HybridOrchestrator
@@ -1506,7 +1506,7 @@ async def _execute_dashboard_action(
         selected_steps=selected_steps,
         progress_callback=task.add_progress,
     )
-    history = _read_run_history(repo_path, config_path, result.run_id)
+    history = _read_run_history(repo_path, config, result.run_id)
     return {
         "mode": "run",
         "repoPath": repo_path,
@@ -1522,13 +1522,12 @@ async def _execute_dashboard_action(
 
 def _read_run_history(
     repo_path: str,
-    config_path: str,
+    config: AppConfig,
     run_id: str,
 ) -> dict[str, Any]:
     if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
         raise ValueError("Invalid run id.")
 
-    config = load_app_config(config_path)
     artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
     run_dir = Path(artifacts_root) / run_id
     summary_path = run_dir / "summary.json"
@@ -1581,7 +1580,7 @@ def _read_run_history(
 
 def _cleanup_run_history(
     repo_path: str,
-    config_path: str,
+    config: AppConfig,
     run_id: str,
     *,
     remove_worktrees: bool,
@@ -1589,7 +1588,6 @@ def _cleanup_run_history(
 ) -> dict[str, Any]:
     if not re.fullmatch(r"[A-Za-z0-9._-]+", run_id):
         raise ValueError("Invalid run id.")
-    config = load_app_config(config_path)
     artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
     worktrees_root = resolve_runtime_path(repo_path, config.runtime.worktrees_dir)
     run_dir = Path(artifacts_root) / run_id
@@ -1606,13 +1604,12 @@ def _cleanup_run_history(
 
 def _prune_run_history(
     repo_path: str,
-    config_path: str,
+    config: AppConfig,
     *,
     keep_latest: int,
     remove_worktrees: bool,
     remove_artifacts: bool,
 ) -> dict[str, Any]:
-    config = load_app_config(config_path)
     artifacts_root = resolve_runtime_path(repo_path, config.runtime.artifacts_dir)
     worktrees_root = resolve_runtime_path(repo_path, config.runtime.worktrees_dir)
     root = Path(artifacts_root)
@@ -1771,7 +1768,7 @@ async def _history_handler(request: web.Request) -> web.Response:
         raise web.HTTPBadRequest(text=str(error)) from error
     run_id = request.match_info["run_id"]
     try:
-        payload = _read_run_history(repo_path, config_path, run_id)
+        payload = _read_run_history(repo_path, config, run_id)
     except FileNotFoundError as error:
         raise web.HTTPNotFound(text=str(error)) from error
     except ValueError as error:
@@ -1825,7 +1822,7 @@ async def _history_cleanup_handler(request: web.Request) -> web.Response:
         payload = await asyncio.to_thread(
             _cleanup_run_history,
             repo_path,
-            config_path,
+            config,
             run_id,
             remove_worktrees=remove_worktrees,
             remove_artifacts=remove_artifacts,
@@ -1858,7 +1855,7 @@ async def _history_prune_handler(request: web.Request) -> web.Response:
     payload = await asyncio.to_thread(
         _prune_run_history,
         repo_path,
-        config_path,
+        config,
         keep_latest=keep_latest,
         remove_worktrees=remove_worktrees,
         remove_artifacts=remove_artifacts,
@@ -1892,8 +1889,8 @@ async def _history_compare_handler(request: web.Request) -> web.Response:
         raise web.HTTPBadRequest(text="runIds must reference two different runs.")
 
     try:
-        left = _read_run_history(repo_path, config_path, normalized_ids[0])
-        right = _read_run_history(repo_path, config_path, normalized_ids[1])
+        left = _read_run_history(repo_path, config, normalized_ids[0])
+        right = _read_run_history(repo_path, config, normalized_ids[1])
     except FileNotFoundError as error:
         raise web.HTTPNotFound(text=str(error)) from error
     except ValueError as error:

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -760,10 +760,16 @@ def _list_run_files(run_dir: Path, limit: int = 200) -> list[dict[str, Any]]:
     if not run_dir.exists():
         return []
     files: list[dict[str, Any]] = []
-    for path in sorted([item for item in run_dir.rglob("*") if item.is_file()])[:limit]:
+    try:
+        candidates = sorted(run_dir.rglob("*"))
+    except OSError:
+        return files
+    for path in candidates[:limit]:
         relative = path.relative_to(run_dir).as_posix()
         suffix = path.suffix.lower().lstrip(".")
         try:
+            if not path.is_file():
+                continue
             size = path.stat().st_size
         except OSError:
             continue
@@ -804,7 +810,11 @@ def _load_run_workspace_manifests(run_dir: Path) -> list[dict[str, Any]]:
     manifests: list[dict[str, Any]] = []
     if not workspaces_dir.exists():
         return manifests
-    for path in sorted(workspaces_dir.glob("*.json")):
+    try:
+        paths = sorted(workspaces_dir.glob("*.json"))
+    except OSError:
+        return manifests
+    for path in paths:
         try:
             with path.open("r", encoding="utf-8") as handle:
                 payload = json.load(handle)

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -818,8 +818,9 @@ def _load_run_workspace_manifests(run_dir: Path) -> list[dict[str, Any]]:
 def _read_artifact_file(run_dir: Path, relative_path: str, limit: int = 200_000) -> dict[str, Any]:
     target = _safe_run_path(run_dir, relative_path)
     raw = target.read_bytes()
+    raw_size = len(raw)
     truncated = False
-    if len(raw) > limit:
+    if raw_size > limit:
         raw = raw[:limit]
         truncated = True
     try:
@@ -828,7 +829,7 @@ def _read_artifact_file(run_dir: Path, relative_path: str, limit: int = 200_000)
     except UnicodeDecodeError:
         content = raw.decode("utf-8", errors="replace")
         encoding = "utf-8-replaced"
-    size = len(raw)
+    size = raw_size
     try:
         size = target.stat().st_size
     except OSError:
@@ -867,6 +868,19 @@ def _cleanup_skip(operation_type: str, reason: str, **details: Any) -> dict[str,
         "exitCode": None,
         "stdout": "",
         "stderr": "",
+    }
+    payload.update(details)
+    return payload
+
+
+def _cleanup_failure(operation_type: str, reason: str, *, error: str, **details: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "type": operation_type,
+        "ok": False,
+        "reason": reason,
+        "exitCode": 1,
+        "stdout": "",
+        "stderr": error,
     }
     payload.update(details)
     return payload
@@ -1004,11 +1018,11 @@ def _cleanup_run_resources(
             )
         except OSError as error:
             operations.append(
-                _cleanup_skip(
+                _cleanup_failure(
                     "artifacts_delete",
                     "Run directory could not be removed.",
-                    path=str(run_dir),
                     error=str(error),
+                    path=str(run_dir),
                 )
             )
         else:

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -276,7 +276,7 @@ def _load_preflight_report(artifacts_dir: str) -> dict[str, Any] | None:
     try:
         with open(preflight_path, "r", encoding="utf-8") as handle:
             return json.load(handle)
-    except (json.JSONDecodeError, UnicodeDecodeError):
+    except (FileNotFoundError, OSError, json.JSONDecodeError, UnicodeDecodeError):
         return None
 
 
@@ -357,9 +357,9 @@ def _build_hermes_overview(config: Any) -> dict[str, Any]:
                 "name": name,
                 "provider": profile.hermes_provider,
                 "model": profile.hermes_model,
-                "toolsets": list(profile.hermes_toolsets),
+                "toolsets": _json_string_list(profile.hermes_toolsets),
                 "source": profile.hermes_source,
-                "maxTurns": profile.hermes_max_turns,
+                "maxTurns": _json_int_value(profile.hermes_max_turns, 0),
             }
         )
 
@@ -388,7 +388,7 @@ def _build_hermes_overview(config: Any) -> dict[str, Any]:
                 if assignment_name and assignment_name in config.assignments:
                     managed_name = config.assignments[assignment_name].agent
             managed_agent = config.managed_agents.get(managed_name) if managed_name else None
-            capabilities = list(managed_agent.capabilities) if managed_agent else []
+            capabilities = _json_string_list(managed_agent.capabilities) if managed_agent else []
             hermes_steps.append(
                 {
                     "id": step.id,
@@ -396,7 +396,7 @@ def _build_hermes_overview(config: Any) -> dict[str, Any]:
                     "profile": profile_name,
                     "managedAgent": managed_name,
                     "assignment": step.assignment,
-                    "dependsOn": list(step.depends_on),
+                    "dependsOn": _json_string_list(step.depends_on),
                     "role": _hermes_role_from_capabilities(capabilities),
                     "capabilities": capabilities,
                 }
@@ -422,7 +422,8 @@ def _build_hermes_overview(config: Any) -> dict[str, Any]:
 async def _build_github_overview(config: Any, repo_path: str) -> dict[str, Any]:
     repo = config.github.repo.strip()
     repo_source = "config" if repo else "unconfigured"
-    if not repo and config.github.use_origin_remote_fallback:
+    use_origin_remote_fallback = _json_bool_value(config.github.use_origin_remote_fallback)
+    if not repo and use_origin_remote_fallback:
         resolved_repo, _, _ = await resolve_github_repo_from_origin(repo_path)
         if resolved_repo:
             repo = resolved_repo
@@ -433,7 +434,7 @@ async def _build_github_overview(config: Any, repo_path: str) -> dict[str, Any]:
         "repo": repo,
         "repoSource": repo_source,
         "baseBranch": config.github.base_branch,
-        "useOriginRemoteFallback": bool(config.github.use_origin_remote_fallback),
+        "useOriginRemoteFallback": use_origin_remote_fallback,
     }
 
 
@@ -683,11 +684,7 @@ def _summarize_recent_runs(
     if not root.exists():
         return runs
 
-    candidates = sorted(
-        [path for path in root.iterdir() if path.is_dir() and path.name.startswith("run-")],
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
-    )
+    candidates = _safe_run_directories(root)
 
     for run_dir in candidates[:limit]:
         summary_path = run_dir / "summary.json"
@@ -766,14 +763,40 @@ def _list_run_files(run_dir: Path, limit: int = 200) -> list[dict[str, Any]]:
     for path in sorted([item for item in run_dir.rglob("*") if item.is_file()])[:limit]:
         relative = path.relative_to(run_dir).as_posix()
         suffix = path.suffix.lower().lstrip(".")
+        try:
+            size = path.stat().st_size
+        except OSError:
+            continue
         files.append(
             {
                 "path": relative,
-                "size": path.stat().st_size,
+                "size": size,
                 "kind": suffix or "file",
             }
         )
     return files
+
+
+def _safe_run_directories(root: Path) -> list[Path]:
+    if not root.exists():
+        return []
+    try:
+        entries = list(root.iterdir())
+    except OSError:
+        return []
+
+    candidates: list[tuple[float, Path]] = []
+    for path in entries:
+        try:
+            if not path.is_dir() or not path.name.startswith("run-"):
+                continue
+            updated_at = path.stat().st_mtime
+        except OSError:
+            continue
+        candidates.append((updated_at, path))
+
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return [path for _, path in candidates]
 
 
 def _load_run_workspace_manifests(run_dir: Path) -> list[dict[str, Any]]:
@@ -785,7 +808,7 @@ def _load_run_workspace_manifests(run_dir: Path) -> list[dict[str, Any]]:
         try:
             with path.open("r", encoding="utf-8") as handle:
                 payload = json.load(handle)
-        except (json.JSONDecodeError, UnicodeDecodeError):
+        except (FileNotFoundError, OSError, json.JSONDecodeError, UnicodeDecodeError):
             continue
         if isinstance(payload, dict):
             manifests.append(payload)
@@ -805,11 +828,16 @@ def _read_artifact_file(run_dir: Path, relative_path: str, limit: int = 200_000)
     except UnicodeDecodeError:
         content = raw.decode("utf-8", errors="replace")
         encoding = "utf-8-replaced"
+    size = len(raw)
+    try:
+        size = target.stat().st_size
+    except OSError:
+        pass
     return {
         "path": relative_path,
         "content": content,
         "truncated": truncated,
-        "size": target.stat().st_size,
+        "size": size,
         "encoding": encoding,
     }
 
@@ -1141,10 +1169,10 @@ def _serialize_plan_for_ui(plan: list[Any]) -> list[dict[str, Any]]:
 
 def _serialize_runtime_snapshot(runtime: Any) -> dict[str, Any]:
     return {
-        "dry_run": bool(runtime.dry_run),
-        "require_step_selection_for_live": bool(runtime.require_step_selection_for_live),
-        "allow_fallback_in_live": bool(runtime.allow_fallback_in_live),
-        "allowed_live_steps": list(runtime.allowed_live_steps),
+        "dry_run": _json_bool_value(runtime.dry_run),
+        "require_step_selection_for_live": _json_bool_value(runtime.require_step_selection_for_live),
+        "allow_fallback_in_live": _json_bool_value(runtime.allow_fallback_in_live),
+        "allowed_live_steps": _json_string_list(runtime.allowed_live_steps),
     }
 
 
@@ -1486,7 +1514,10 @@ def _read_run_history(
             raise ValueError(f"Run context must be a JSON object for {run_id}.")
 
     preflight = _load_preflight_report(str(run_dir))
-    updated_at = datetime.fromtimestamp(run_dir.stat().st_mtime, timezone.utc).isoformat()
+    try:
+        updated_at = datetime.fromtimestamp(run_dir.stat().st_mtime, timezone.utc).isoformat()
+    except OSError as error:
+        raise FileNotFoundError(f"Run summary not found for {run_id}.") from error
     return {
         "runId": run_id,
         "updatedAt": updated_at,
@@ -1549,11 +1580,7 @@ def _prune_run_history(
             "removed": [],
         }
 
-    run_dirs = sorted(
-        [path for path in root.iterdir() if path.is_dir() and path.name.startswith("run-")],
-        key=lambda path: path.stat().st_mtime,
-        reverse=True,
-    )
+    run_dirs = _safe_run_directories(root)
     removed: list[dict[str, Any]] = []
     for run_dir in run_dirs[keep_latest:]:
         removed.append(

--- a/openclaw_v2/worktree.py
+++ b/openclaw_v2/worktree.py
@@ -143,7 +143,11 @@ class WorktreeManager:
             except RuntimeError as error:
                 if not self._workspace_absent_error(str(error)):
                     raise
-            await self._run(cleanup_commands[1])
+            try:
+                await self._run(cleanup_commands[1])
+            except RuntimeError as error:
+                if not self._branch_absent_error(str(error)):
+                    raise
             work_item.metadata["workspace_cleanup_status"] = "completed"
 
     async def _git_repo_root(self, repo_path: str) -> str:
@@ -220,6 +224,19 @@ class WorktreeManager:
                 "not a working tree",
                 "does not exist",
                 "no such file or directory",
+            )
+        )
+
+    @staticmethod
+    def _branch_absent_error(message: str) -> bool:
+        normalized = message.lower()
+        return any(
+            token in normalized
+            for token in (
+                "not found",
+                "does not exist",
+                "no such ref",
+                "unknown branch",
             )
         )
 

--- a/openclaw_v2/worktree.py
+++ b/openclaw_v2/worktree.py
@@ -138,8 +138,12 @@ class WorktreeManager:
                 work_item.metadata["workspace_cleanup_status"] = "planned"
                 continue
 
-            for command in cleanup_commands:
-                await self._run(command)
+            try:
+                await self._run(cleanup_commands[0])
+            except RuntimeError as error:
+                if not self._workspace_absent_error(str(error)):
+                    raise
+            await self._run(cleanup_commands[1])
             work_item.metadata["workspace_cleanup_status"] = "completed"
 
     async def _git_repo_root(self, repo_path: str) -> str:
@@ -205,6 +209,19 @@ class WorktreeManager:
         # Keep orchestration branches flat to avoid git ref file/dir conflicts.
         raw = f"openclaw-{run_id.lower()}-{work_item_id.lower()}"
         return re.sub(r"[^a-z0-9_-]+", "-", raw).strip("-")
+
+    @staticmethod
+    def _workspace_absent_error(message: str) -> bool:
+        normalized = message.lower()
+        return any(
+            token in normalized
+            for token in (
+                "already absent",
+                "not a working tree",
+                "does not exist",
+                "no such file or directory",
+            )
+        )
 
     @staticmethod
     def _default_base_ref() -> str:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,3 +1,4 @@
+import os
 import tempfile
 import textwrap
 import unittest
@@ -49,17 +50,19 @@ class ConfigLoaderTests(unittest.TestCase):
         with tempfile.NamedTemporaryFile("w+", suffix=".yaml", encoding="utf-8") as handle:
             handle.write("runtime:\n  pipeline: demo\n")
             handle.flush()
+            real_exists = os.path.exists
+
+            def flaky_exists(path: str) -> bool:
+                return False if os.fspath(path) == handle.name else real_exists(path)
+
             with mock.patch("openclaw_v2.config.yaml", None):
                 with mock.patch(
                     "openclaw_v2.config.subprocess.run",
-                    side_effect=subprocess.CalledProcessError(
-                        returncode=1,
-                        cmd=["ruby"],
-                        stderr=f"ruby: No such file or directory - {handle.name}\n",
-                    ),
+                    side_effect=subprocess.CalledProcessError(returncode=1, cmd=["ruby"], output="", stderr=""),
                 ):
-                    with self.assertRaises(FileNotFoundError):
-                        _load_yaml(handle.name)
+                    with mock.patch("openclaw_v2.config.os.path.exists", side_effect=flaky_exists):
+                        with self.assertRaises(FileNotFoundError):
+                            _load_yaml(handle.name)
 
     def test_load_app_config_reads_openclaw_profile_fields(self) -> None:
         content = textwrap.dedent(

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,6 +1,7 @@
 import tempfile
 import textwrap
 import unittest
+import subprocess
 from unittest import mock
 from types import SimpleNamespace
 
@@ -43,6 +44,22 @@ class ConfigLoaderTests(unittest.TestCase):
 
         self.assertEqual(data["runtime"]["pipeline"], "hybrid_default")
         self.assertEqual(data["github"]["repo"], "owner/repo")
+
+    def test_load_yaml_ruby_fallback_raises_filenotfounderror_when_config_disappears(self) -> None:
+        with tempfile.NamedTemporaryFile("w+", suffix=".yaml", encoding="utf-8") as handle:
+            handle.write("runtime:\n  pipeline: demo\n")
+            handle.flush()
+            with mock.patch("openclaw_v2.config.yaml", None):
+                with mock.patch(
+                    "openclaw_v2.config.subprocess.run",
+                    side_effect=subprocess.CalledProcessError(
+                        returncode=1,
+                        cmd=["ruby"],
+                        stderr=f"ruby: No such file or directory - {handle.name}\n",
+                    ),
+                ):
+                    with self.assertRaises(FileNotFoundError):
+                        _load_yaml(handle.name)
 
     def test_load_app_config_reads_openclaw_profile_fields(self) -> None:
         content = textwrap.dedent(

--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -25,6 +25,19 @@ class MainV2PrintTests(unittest.TestCase):
 
         self.assertEqual(output, "")
 
+    def test_print_preflight_tolerates_non_object_report(self) -> None:
+        with (
+            mock.patch("main_v2.os.path.exists", return_value=True),
+            mock.patch("main_v2.open", mock.mock_open(read_data="[]")),
+            mock.patch("main_v2.json.load", return_value=[]),
+            io.StringIO() as buffer,
+            redirect_stdout(buffer),
+        ):
+            _print_preflight("/tmp/run-1")
+            output = buffer.getvalue()
+
+        self.assertEqual(output, "")
+
     def test_print_result_includes_block_reasons(self) -> None:
         run_result = RunResult(
             run_id="run-1",

--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -6,13 +6,25 @@ import unittest
 from contextlib import redirect_stdout
 from unittest import mock
 
-from main_v2 import _print_plan_diagnostics, _print_result, _validate_live_policy, main
+from main_v2 import _print_plan_diagnostics, _print_preflight, _print_result, _validate_live_policy, main
 from openclaw_v2.config import load_app_config
 from openclaw_v2.models import AgentResult, AgentType, ExecutionMode, RunResult, TaskStatus, WorkItem
 from openclaw_v2.orchestrator import HybridOrchestrator
 
 
 class MainV2PrintTests(unittest.TestCase):
+    def test_print_preflight_tolerates_report_disappearing_after_exists(self) -> None:
+        with (
+            mock.patch("main_v2.os.path.exists", return_value=True),
+            mock.patch("main_v2.open", side_effect=FileNotFoundError("preflight disappeared")),
+            io.StringIO() as buffer,
+            redirect_stdout(buffer),
+        ):
+            _print_preflight("/tmp/run-1")
+            output = buffer.getvalue()
+
+        self.assertEqual(output, "")
+
     def test_print_result_includes_block_reasons(self) -> None:
         run_result = RunResult(
             run_id="run-1",

--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -1,6 +1,7 @@
 import io
 import os
 import sys
+import tempfile
 import unittest
 from contextlib import redirect_stdout
 from unittest import mock
@@ -369,6 +370,28 @@ class MainV2PolicyTests(unittest.TestCase):
 
 
 class MainV2WebModeTests(unittest.IsolatedAsyncioTestCase):
+    async def test_main_reports_missing_config_as_systemexit(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            missing_config = os.path.join(temp_dir, "missing-config.yaml")
+            with (
+                mock.patch.object(
+                    sys,
+                    "argv",
+                    [
+                        "main_v2.py",
+                        "--config",
+                        missing_config,
+                        "--doctor-config",
+                    ],
+                ),
+                mock.patch("builtins.input", side_effect=AssertionError("should not prompt when config is missing")),
+            ):
+                with self.assertRaises(SystemExit) as error:
+                    await main()
+
+        self.assertIn("Config file not found", str(error.exception))
+        self.assertIn(missing_config, str(error.exception))
+
     async def test_main_runs_doctor_config_and_exits_without_prompting(self) -> None:
         with (
             mock.patch.object(sys, "argv", ["main_v2.py", "--doctor-config"]),

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -336,6 +336,51 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[0].status, CheckStatus.PASSED)
         self.assertIn("usable inference provider path", checks[0].message)
 
+    def test_hermes_provider_preflight_treats_parse_failures_as_missing_config_when_file_disappears(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            config_path = os.path.join(hermes_home, "config.yaml")
+            with open(config_path, "w", encoding="utf-8") as handle:
+                handle.write("model:\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n")
+            with open(os.path.join(hermes_home, ".env"), "w", encoding="utf-8") as handle:
+                handle.write("OPENROUTER_API_KEY=test-key\n")
+
+            real_exists = os.path.exists
+            config_exists_calls = 0
+
+            def flaky_exists(path: str) -> bool:
+                nonlocal config_exists_calls
+                if os.fspath(path) == config_path:
+                    config_exists_calls += 1
+                    return config_exists_calls == 1
+                return real_exists(path)
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    with mock.patch("openclaw_v2.preflight.os.path.exists", side_effect=flaky_exists):
+                        with mock.patch(
+                            "openclaw_v2.preflight._load_yaml",
+                            side_effect=RuntimeError("Failed to parse YAML config /tmp/.hermes/config.yaml: No such file or directory"),
+                        ):
+                            checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertIn("usable inference provider path", checks[0].message)
+
     def test_hermes_provider_preflight_checks_tool_call_support_for_custom_endpoint(self) -> None:
         config = load_app_config("config_v2.yaml")
         runner = PreflightRunner(config)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -519,6 +519,47 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[0].status, CheckStatus.FAILED)
         self.assertIn("runtime probe failed", checks[0].message)
 
+    async def test_hermes_runtime_probe_treats_missing_probe_file_as_warning(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as repo_path:
+            probe_file = os.path.join(repo_path, "AGENTS.md")
+            with open(probe_file, "w", encoding="utf-8") as handle:
+                handle.write("# test\n")
+
+            real_exists = os.path.exists
+            probe_exists_calls = 0
+
+            def flaky_exists(path: str) -> bool:
+                nonlocal probe_exists_calls
+                if os.fspath(path) == probe_file:
+                    probe_exists_calls += 1
+                    return probe_exists_calls == 1
+                return real_exists(path)
+
+            with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                with mock.patch("openclaw_v2.preflight.os.path.exists", side_effect=flaky_exists):
+                    with mock.patch(
+                        "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                        new=mock.AsyncMock(return_value=_FakeProcess(1, "API call failed after 3 retries: Connection error.\n")),
+                    ):
+                        checks = await runner._check_hermes_runtime(repo_path, plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.WARNING)
+        self.assertIn("probe file disappeared", checks[0].message)
+
     def test_github_workflow_preflight_fails_when_file_is_missing_in_live_mode(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.dry_run = False

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -298,6 +298,44 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[0].status, CheckStatus.WARNING)
         self.assertIn("no ready inference provider", checks[0].message)
 
+    def test_hermes_provider_preflight_tolerates_config_disappearing_during_read(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            config_path = os.path.join(hermes_home, "config.yaml")
+            with open(config_path, "w", encoding="utf-8") as handle:
+                handle.write("model:\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n")
+            with open(os.path.join(hermes_home, ".env"), "w", encoding="utf-8") as handle:
+                handle.write("OPENROUTER_API_KEY=test-key\n")
+
+            real_open = open
+
+            def flaky_open(file, *args, **kwargs):
+                if os.fspath(file) == config_path:
+                    raise FileNotFoundError("hermes config disappeared during read")
+                return real_open(file, *args, **kwargs)
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    with mock.patch("builtins.open", side_effect=flaky_open):
+                        checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertIn("usable inference provider path", checks[0].message)
+
     def test_hermes_provider_preflight_checks_tool_call_support_for_custom_endpoint(self) -> None:
         config = load_app_config("config_v2.yaml")
         runner = PreflightRunner(config)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -260,6 +260,44 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[0].status, CheckStatus.PASSED)
         self.assertIn("usable inference provider path", checks[0].message)
 
+    def test_hermes_provider_preflight_tolerates_env_disappearing_during_read(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request with local Hermes",
+                profile="hermes_local",
+                agent=AgentType.HERMES,
+                mode=ExecutionMode.HERMES,
+                prompt_template="",
+            )
+        ]
+
+        with tempfile.TemporaryDirectory() as home_dir:
+            hermes_home = os.path.join(home_dir, ".hermes")
+            os.makedirs(hermes_home, exist_ok=True)
+            with open(os.path.join(hermes_home, "config.yaml"), "w", encoding="utf-8") as handle:
+                handle.write("model:\n  provider: auto\n  base_url: https://openrouter.ai/api/v1\n")
+            env_path = os.path.join(hermes_home, ".env")
+            with open(env_path, "w", encoding="utf-8") as handle:
+                handle.write("OPENROUTER_API_KEY=test-key\n")
+
+            real_open = open
+
+            def flaky_open(file, *args, **kwargs):
+                if os.fspath(file) == env_path:
+                    raise FileNotFoundError("hermes env disappeared during read")
+                return real_open(file, *args, **kwargs)
+
+            with mock.patch.dict("os.environ", {"HOME": home_dir}, clear=True):
+                with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/hermes"):
+                    with mock.patch("builtins.open", side_effect=flaky_open):
+                        checks = runner._check_hermes_profiles(plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.WARNING)
+        self.assertIn("no ready inference provider", checks[0].message)
+
     def test_hermes_provider_preflight_checks_tool_call_support_for_custom_endpoint(self) -> None:
         config = load_app_config("config_v2.yaml")
         runner = PreflightRunner(config)

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -259,6 +259,56 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         payload = await response.json()
         self.assertFalse(any(item["runId"] == "run-vanish" for item in payload["recentRuns"]))
 
+    async def test_bootstrap_tolerates_preflight_disappearing_during_read(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-preflight-race")
+        metadata_dir = os.path.join(run_dir, "metadata")
+        os.makedirs(metadata_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-preflight-race", "plan": [], "results": [], "success": True}, handle)
+        with open(os.path.join(run_dir, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "demo"}, handle)
+        with open(os.path.join(metadata_dir, "preflight.json"), "w", encoding="utf-8") as handle:
+            json.dump({"checks": [{"name": "noop", "status": "passed"}]}, handle)
+
+        real_open = open
+
+        def flaky_open(file, *args, **kwargs):
+            if isinstance(file, str) and file.endswith("/metadata/preflight.json"):
+                raise FileNotFoundError("preflight disappeared during read")
+            return real_open(file, *args, **kwargs)
+
+        with mock.patch("builtins.open", side_effect=flaky_open):
+            response = await self.client.get("/api/bootstrap")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertTrue(any(item["runId"] == "run-preflight-race" for item in payload["recentRuns"]))
+
+    async def test_bootstrap_skips_runs_if_run_directory_stat_disappears_during_sort(self) -> None:
+        runs_root = os.path.join(self.repo_path, ".openclaw", "runs")
+        os.makedirs(runs_root, exist_ok=True)
+        for index, run_id in enumerate(["run-a", "run-stat-race", "run-c"], start=1):
+            run_dir = os.path.join(runs_root, run_id)
+            os.makedirs(run_dir, exist_ok=True)
+            with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+                json.dump({"run_id": run_id, "plan": [], "results": [], "success": True}, handle)
+            os.utime(run_dir, (index, index))
+
+        path_cls = Path(self.repo_path).__class__
+        real_stat = path_cls.stat
+
+        def flaky_stat(path_self, *args, **kwargs):
+            if path_self.name == "run-stat-race":
+                raise FileNotFoundError("run disappeared while sorting recent runs")
+            return real_stat(path_self, *args, **kwargs)
+
+        with mock.patch.object(path_cls, "stat", autospec=True, side_effect=flaky_stat):
+            response = await self.client.get("/api/bootstrap")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertFalse(any(item["runId"] == "run-stat-race" for item in payload["recentRuns"]))
+
     async def test_bootstrap_tolerates_non_list_summary_sections(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-weird-summary")
         os.makedirs(run_dir, exist_ok=True)
@@ -298,6 +348,45 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(history_response.status, 200)
         history_payload = await history_response.json()
         self.assertFalse(history_payload["insights"]["dryRun"])
+
+    async def test_bootstrap_treats_runtime_snapshot_flags_and_lists_conservatively(self) -> None:
+        class DummyOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+
+            def build_plan(self, selected_steps=None):
+                return []
+
+        with mock.patch("openclaw_v2.web.load_app_config") as load_config, mock.patch(
+            "openclaw_v2.web.HybridOrchestrator",
+            DummyOrchestrator,
+        ):
+            config = load_config.return_value
+            config.runtime.pipeline = "demo_pipeline"
+            config.runtime.dry_run = "false"
+            config.runtime.require_step_selection_for_live = "false"
+            config.runtime.allow_fallback_in_live = "true"
+            config.runtime.allowed_live_steps = "implement"
+            config.runtime.artifacts_dir = ".openclaw/runs"
+            config.runtime.worktrees_dir = "/tmp/openclaw-worktrees"
+            config.github.repo = ""
+            config.github.base_branch = "main"
+            config.github.use_origin_remote_fallback = "true"
+            config.profiles = {}
+            config.managed_agents = {}
+            config.assignments = {}
+            config.pipelines = {"demo_pipeline": []}
+
+            response = await self.client.get("/api/bootstrap")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        runtime = payload["snapshot"]["runtime"]
+        self.assertFalse(runtime["dry_run"])
+        self.assertFalse(runtime["require_step_selection_for_live"])
+        self.assertFalse(runtime["allow_fallback_in_live"])
+        self.assertEqual(runtime["allowed_live_steps"], [])
+        self.assertFalse(payload["integrations"]["github"]["useOriginRemoteFallback"])
 
     async def test_bootstrap_rejects_in_repo_config_override_that_changes_artifacts_root(self) -> None:
         alt_dir = os.path.join(self.repo_path, "configs")
@@ -387,6 +476,58 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         file_payload = await file_response.json()
         self.assertIn("hello prompt", file_payload["content"])
 
+    async def test_history_endpoint_skips_files_that_disappear_during_listing(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-list-race")
+        prompt_path = Path(run_dir) / "prompts" / "implement.txt"
+        os.makedirs(prompt_path.parent, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-list-race", "plan": [], "results": [], "success": True}, handle)
+        with open(os.path.join(run_dir, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "demo"}, handle)
+        prompt_path.write_text("hello prompt\n", encoding="utf-8")
+
+        path_cls = prompt_path.__class__
+        real_stat = path_cls.stat
+
+        def flaky_is_file(path_self, *args, **kwargs):
+            return os.path.isfile(path_self)
+
+        def flaky_stat(path_self, *args, **kwargs):
+            if path_self.name == "implement.txt" and path_self.parent.name == "prompts":
+                raise FileNotFoundError("artifact disappeared during listing")
+            return real_stat(path_self, *args, **kwargs)
+
+        with mock.patch.object(path_cls, "is_file", autospec=True, side_effect=flaky_is_file):
+            with mock.patch.object(path_cls, "stat", autospec=True, side_effect=flaky_stat):
+                response = await self.client.get("/api/history/run-list-race")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-list-race")
+        self.assertEqual([item["path"] for item in payload["files"]], ["context.json", "summary.json"])
+
+    async def test_history_file_endpoint_returns_content_if_file_disappears_after_read(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-file-race")
+        prompt_text = "hello prompt\n"
+
+        class VanishingArtifact:
+            def read_bytes(self) -> bytes:
+                return prompt_text.encode("utf-8")
+
+            def stat(self):
+                raise FileNotFoundError("artifact disappeared after read")
+
+        with mock.patch("openclaw_v2.web._safe_run_path", return_value=VanishingArtifact()):
+            response = await self.client.get("/api/history/run-file-race/file?path=prompts/implement.txt")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["path"], "prompts/implement.txt")
+        self.assertEqual(payload["content"], prompt_text)
+        self.assertEqual(payload["size"], len(prompt_text.encode("utf-8")))
+        self.assertFalse(payload["truncated"])
+        self.assertEqual(payload["encoding"], "utf-8")
+
     async def test_history_endpoint_rejects_malformed_summary_json(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-bad-summary")
         os.makedirs(run_dir, exist_ok=True)
@@ -454,6 +595,26 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
 
         with mock.patch.object(Path, "open", autospec=True, side_effect=flaky_open):
             response = await self.client.get("/api/history/run-vanish")
+
+        self.assertEqual(response.status, 404)
+        self.assertIn("Run summary not found", await response.text())
+
+    async def test_history_endpoint_returns_404_if_run_directory_disappears_during_stamp_read(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-stamp-vanish")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-stamp-vanish", "plan": [], "results": [], "success": True}, handle)
+
+        path_cls = Path(self.repo_path).__class__
+        real_stat = path_cls.stat
+
+        def flaky_stat(path_self, *args, **kwargs):
+            if path_self.as_posix().endswith("/run-stamp-vanish"):
+                raise FileNotFoundError("run directory disappeared during stamp read")
+            return real_stat(path_self, *args, **kwargs)
+
+        with mock.patch.object(path_cls, "stat", autospec=True, side_effect=flaky_stat):
+            response = await self.client.get("/api/history/run-stamp-vanish")
 
         self.assertEqual(response.status, 404)
         self.assertIn("Run summary not found", await response.text())
@@ -733,6 +894,35 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         payload = await response.json()
         self.assertEqual(payload["operations"], [])
 
+    async def test_cleanup_endpoint_skips_workspace_manifests_that_disappear_during_read(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-vanish-manifest")
+        workspaces_dir = os.path.join(run_dir, "workspaces")
+        os.makedirs(workspaces_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-vanish-manifest", "plan": [], "results": [], "success": True}, handle)
+        manifest_path = os.path.join(workspaces_dir, "implement.json")
+        with open(manifest_path, "w", encoding="utf-8") as handle:
+            json.dump({"workspace_path": run_dir, "branch_name": "openclaw-run-vanish-manifest-implement"}, handle)
+
+        path_cls = Path(self.repo_path).__class__
+        real_open = path_cls.open
+
+        def flaky_open(path_self, *args, **kwargs):
+            if path_self.name == "implement.json" and path_self.parent.name == "workspaces":
+                raise FileNotFoundError("workspace manifest disappeared during read")
+            return real_open(path_self, *args, **kwargs)
+
+        with mock.patch.object(path_cls, "open", autospec=True, side_effect=flaky_open):
+            response = await self.client.post(
+                "/api/history/run-vanish-manifest/cleanup",
+                json={"removeWorktrees": True, "removeArtifacts": False},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["operations"], [])
+
     async def test_cleanup_endpoint_requires_housekeeping_token(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-no-token")
         os.makedirs(run_dir, exist_ok=True)
@@ -868,6 +1058,38 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(os.path.exists(os.path.join(runs_root, "run-c")))
         self.assertFalse(os.path.exists(os.path.join(runs_root, "run-a")))
         self.assertFalse(os.path.exists(os.path.join(runs_root, "run-b")))
+
+    async def test_prune_endpoint_skips_runs_if_run_directory_stat_disappears_during_sort(self) -> None:
+        runs_root = os.path.join(self.repo_path, ".openclaw", "runs")
+        os.makedirs(runs_root, exist_ok=True)
+        for index, run_id in enumerate(["run-a", "run-stat-race", "run-c"], start=1):
+            run_dir = os.path.join(runs_root, run_id)
+            os.makedirs(run_dir, exist_ok=True)
+            with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+                json.dump({"run_id": run_id, "plan": [], "results": [], "success": True}, handle)
+            os.utime(run_dir, (index, index))
+
+        path_cls = Path(self.repo_path).__class__
+        real_stat = path_cls.stat
+
+        def flaky_stat(path_self, *args, **kwargs):
+            if path_self.name == "run-stat-race":
+                raise FileNotFoundError("run disappeared while sorting prune candidates")
+            return real_stat(path_self, *args, **kwargs)
+
+        with mock.patch.object(path_cls, "stat", autospec=True, side_effect=flaky_stat):
+            response = await self.client.post(
+                "/api/history/prune",
+                json={"keepLatest": 0},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(len(payload["removed"]), 2)
+        self.assertTrue(os.path.exists(os.path.join(runs_root, "run-stat-race")))
+        self.assertFalse(os.path.exists(os.path.join(runs_root, "run-a")))
+        self.assertFalse(os.path.exists(os.path.join(runs_root, "run-c")))
 
     async def test_prune_endpoint_rejects_non_numeric_keep_latest(self) -> None:
         response = await self.client.post(

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -876,6 +876,27 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["runId"], "run-cleanup")
         self.assertFalse(os.path.exists(run_dir))
 
+    async def test_cleanup_endpoint_tolerates_run_directory_disappearing_before_artifact_delete(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-cleanup-race")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-cleanup-race", "plan": [], "results": [], "success": True}, handle)
+
+        def flaky_rmtree(path, *args, **kwargs):
+            raise FileNotFoundError("run directory disappeared before artifact delete")
+
+        with mock.patch("openclaw_v2.web.shutil.rmtree", side_effect=flaky_rmtree):
+            response = await self.client.post(
+                "/api/history/run-cleanup-race/cleanup",
+                json={"removeWorktrees": False, "removeArtifacts": True},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-cleanup-race")
+        self.assertTrue(any(item["type"] == "artifacts_delete" for item in payload["operations"]))
+
     async def test_cleanup_endpoint_skips_invalid_utf8_workspace_manifests(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-invalid-manifest")
         workspaces_dir = os.path.join(run_dir, "workspaces")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -528,6 +528,25 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertFalse(payload["truncated"])
         self.assertEqual(payload["encoding"], "utf-8")
 
+    async def test_history_file_endpoint_uses_original_size_when_stat_disappears_after_truncation(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-truncated-race")
+        prompt_text = "x" * 200_100
+
+        class TruncatedArtifact:
+            def read_bytes(self) -> bytes:
+                return prompt_text.encode("utf-8")
+
+            def stat(self):
+                raise FileNotFoundError("artifact disappeared after truncation")
+
+        with mock.patch("openclaw_v2.web._safe_run_path", return_value=TruncatedArtifact()):
+            response = await self.client.get("/api/history/run-truncated-race/file?path=prompts/implement.txt")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["size"], len(prompt_text.encode("utf-8")))
+        self.assertTrue(payload["truncated"])
+
     async def test_history_endpoint_rejects_malformed_summary_json(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-bad-summary")
         os.makedirs(run_dir, exist_ok=True)
@@ -896,6 +915,27 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         payload = await response.json()
         self.assertEqual(payload["runId"], "run-cleanup-race")
         self.assertTrue(any(item["type"] == "artifacts_delete" for item in payload["operations"]))
+
+    async def test_cleanup_endpoint_marks_artifact_delete_errors_as_failures(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-cleanup-failure")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-cleanup-failure", "plan": [], "results": [], "success": True}, handle)
+
+        with mock.patch("openclaw_v2.web.shutil.rmtree", side_effect=PermissionError("denied")):
+            response = await self.client.post(
+                "/api/history/run-cleanup-failure/cleanup",
+                json={"removeWorktrees": False, "removeArtifacts": True},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        artifact_ops = [item for item in payload["operations"] if item["type"] == "artifacts_delete"]
+        self.assertEqual(len(artifact_ops), 1)
+        self.assertFalse(artifact_ops[0]["ok"])
+        self.assertNotIn("skipped", artifact_ops[0])
+        self.assertIn("denied", artifact_ops[0]["stderr"])
 
     async def test_cleanup_endpoint_skips_invalid_utf8_workspace_manifests(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-invalid-manifest")

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -506,6 +506,30 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["runId"], "run-list-race")
         self.assertEqual([item["path"] for item in payload["files"]], ["context.json", "summary.json"])
 
+    async def test_history_endpoint_tolerates_artifact_tree_glob_failure(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-rglob-race")
+        os.makedirs(os.path.join(run_dir, "prompts"), exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-rglob-race", "plan": [], "results": [], "success": True}, handle)
+        with open(os.path.join(run_dir, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "demo"}, handle)
+
+        path_cls = Path(self.repo_path).__class__
+        real_rglob = path_cls.rglob
+
+        def flaky_rglob(path_self, pattern):
+            if path_self.name == "run-rglob-race":
+                raise FileNotFoundError("artifact tree disappeared during glob")
+            return real_rglob(path_self, pattern)
+
+        with mock.patch.object(path_cls, "rglob", autospec=True, side_effect=flaky_rglob):
+            response = await self.client.get("/api/history/run-rglob-race")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-rglob-race")
+        self.assertEqual(payload["files"], [])
+
     async def test_history_file_endpoint_returns_content_if_file_disappears_after_read(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-file-race")
         prompt_text = "hello prompt\n"
@@ -976,6 +1000,32 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         with mock.patch.object(path_cls, "open", autospec=True, side_effect=flaky_open):
             response = await self.client.post(
                 "/api/history/run-vanish-manifest/cleanup",
+                json={"removeWorktrees": True, "removeArtifacts": False},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["operations"], [])
+
+    async def test_cleanup_endpoint_tolerates_workspace_manifest_glob_failure(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-glob-race")
+        workspaces_dir = os.path.join(run_dir, "workspaces")
+        os.makedirs(workspaces_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-glob-race", "plan": [], "results": [], "success": True}, handle)
+
+        path_cls = Path(self.repo_path).__class__
+        real_glob = path_cls.glob
+
+        def flaky_glob(path_self, pattern):
+            if path_self.name == "workspaces" and pattern == "*.json":
+                raise FileNotFoundError("workspace manifest glob disappeared")
+            return real_glob(path_self, pattern)
+
+        with mock.patch.object(path_cls, "glob", autospec=True, side_effect=flaky_glob):
+            response = await self.client.post(
+                "/api/history/run-glob-race/cleanup",
                 json={"removeWorktrees": True, "removeArtifacts": False},
                 headers=self.housekeeping_headers,
             )

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -10,6 +10,7 @@ from unittest import mock
 from aiohttp.test_utils import TestClient, TestServer
 
 from openclaw_v2.models import AgentResult, AgentType, ExecutionMode, RunResult, TaskStatus, WorkItem
+from openclaw_v2.config import load_app_config
 from openclaw_v2.web import APP_HOUSEKEEPING_TOKEN, APP_TASK_MANAGER, create_web_app
 
 
@@ -476,6 +477,25 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         file_payload = await file_response.json()
         self.assertIn("hello prompt", file_payload["content"])
 
+    async def test_history_endpoint_tolerates_config_disappearing_after_initial_load(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-1")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-1", "plan": [], "results": [], "success": True}, handle)
+        with open(os.path.join(run_dir, "context.json"), "w", encoding="utf-8") as handle:
+            json.dump({"repo_path": self.repo_path, "user_request": "demo"}, handle)
+
+        loaded = load_app_config(self.config_path)
+        with mock.patch(
+            "openclaw_v2.web.load_app_config",
+            side_effect=[loaded, FileNotFoundError("config vanished after first load")],
+        ):
+            response = await self.client.get("/api/history/run-1")
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-1")
+
     async def test_history_endpoint_skips_files_that_disappear_during_listing(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-list-race")
         prompt_path = Path(run_dir) / "prompts" / "implement.txt"
@@ -919,6 +939,28 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(payload["runId"], "run-cleanup")
         self.assertFalse(os.path.exists(run_dir))
 
+    async def test_cleanup_endpoint_tolerates_config_disappearing_after_initial_load(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-cleanup")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump({"run_id": "run-cleanup", "plan": [], "results": [], "success": True}, handle)
+
+        loaded = load_app_config(self.config_path)
+        with mock.patch(
+            "openclaw_v2.web.load_app_config",
+            side_effect=[loaded, FileNotFoundError("config vanished after first load")],
+        ):
+            response = await self.client.post(
+                "/api/history/run-cleanup/cleanup",
+                json={},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(payload["runId"], "run-cleanup")
+        self.assertFalse(os.path.exists(run_dir))
+
     async def test_cleanup_endpoint_tolerates_run_directory_disappearing_before_artifact_delete(self) -> None:
         run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-cleanup-race")
         os.makedirs(run_dir, exist_ok=True)
@@ -1169,6 +1211,31 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(os.path.exists(os.path.join(runs_root, "run-c")))
         self.assertFalse(os.path.exists(os.path.join(runs_root, "run-a")))
         self.assertFalse(os.path.exists(os.path.join(runs_root, "run-b")))
+
+    async def test_prune_endpoint_tolerates_config_disappearing_after_initial_load(self) -> None:
+        runs_root = os.path.join(self.repo_path, ".openclaw", "runs")
+        os.makedirs(runs_root, exist_ok=True)
+        for index, run_id in enumerate(["run-a", "run-b", "run-c"], start=1):
+            run_dir = os.path.join(runs_root, run_id)
+            os.makedirs(run_dir, exist_ok=True)
+            with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+                json.dump({"run_id": run_id, "plan": [], "results": [], "success": True}, handle)
+            os.utime(run_dir, (index, index))
+
+        loaded = load_app_config(self.config_path)
+        with mock.patch(
+            "openclaw_v2.web.load_app_config",
+            side_effect=[loaded, FileNotFoundError("config vanished after first load")],
+        ):
+            response = await self.client.post(
+                "/api/history/prune",
+                json={"keepLatest": 1, "removeWorktrees": False, "removeArtifacts": True},
+                headers=self.housekeeping_headers,
+            )
+
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        self.assertEqual(len(payload["removed"]), 2)
 
     async def test_prune_endpoint_skips_runs_if_run_directory_stat_disappears_during_sort(self) -> None:
         runs_root = os.path.join(self.repo_path, ".openclaw", "runs")

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -123,5 +123,55 @@ class WorktreeManagerReuseTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(commands[0][3:5], ["worktree", "remove"])
         self.assertEqual(commands[1][3:5], ["branch", "-D"])
         self.assertEqual(work_item.metadata["workspace_cleanup_status"], "completed")
+
+    async def test_cleanup_continues_when_branch_disappears_after_workspace_cleanup(self) -> None:
+        manager = WorktreeManager()
+        context = ExecutionContext(
+            run_id="run-1",
+            user_request="test",
+            repo_path="/tmp/repo",
+            dry_run=False,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+        with tempfile.TemporaryDirectory() as workspace_path:
+            work_item = WorkItem(
+                id="implement",
+                title="Implement with OpenClaw",
+                profile="openclaw_local",
+                agent=AgentType.OPENCLAW,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+                workspace_path=workspace_path,
+                branch_name="openclaw-run-1-implement",
+                metadata={
+                    "workspace_strategy": "git-worktree",
+                    "workspace_repo_root": context.repo_path,
+                },
+            )
+
+            commands: list[list[str]] = []
+
+            async def fake_run(command: list[str]) -> None:
+                commands.append(command)
+                if command[3:5] == ["worktree", "remove"]:
+                    raise RuntimeError("workspace already absent")
+                if command[3:5] == ["branch", "-D"]:
+                    raise RuntimeError("error: branch 'openclaw-run-1-implement' not found.")
+
+            with mock.patch.object(WorktreeManager, "_run", side_effect=fake_run):
+                await manager.cleanup(
+                    [work_item],
+                    context,
+                    cleanup_enabled=True,
+                    retain_failed_worktrees=False,
+                    run_success=True,
+                    run_has_failures=False,
+                )
+
+        self.assertEqual(len(commands), 2)
+        self.assertEqual(commands[0][3:5], ["worktree", "remove"])
+        self.assertEqual(commands[1][3:5], ["branch", "-D"])
+        self.assertEqual(work_item.metadata["workspace_cleanup_status"], "completed")
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1,3 +1,5 @@
+import tempfile
+from unittest import mock
 import unittest
 
 from openclaw_v2.models import AgentType, ExecutionContext, ExecutionMode, WorkItem
@@ -73,5 +75,53 @@ class WorktreeManagerReuseTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(work_item.workspace_path, "/tmp/worktrees/implement")
         self.assertEqual(work_item.branch_name, "openclaw-run-1-implement")
         self.assertEqual(work_item.metadata["workspace_strategy"], "git-worktree")
+
+    async def test_cleanup_continues_when_workspace_disappears_before_remove_command(self) -> None:
+        manager = WorktreeManager()
+        context = ExecutionContext(
+            run_id="run-1",
+            user_request="test",
+            repo_path="/tmp/repo",
+            dry_run=False,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+        with tempfile.TemporaryDirectory() as workspace_path:
+            work_item = WorkItem(
+                id="implement",
+                title="Implement with OpenClaw",
+                profile="openclaw_local",
+                agent=AgentType.OPENCLAW,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+                workspace_path=workspace_path,
+                branch_name="openclaw-run-1-implement",
+                metadata={
+                    "workspace_strategy": "git-worktree",
+                    "workspace_repo_root": context.repo_path,
+                },
+            )
+
+            commands: list[list[str]] = []
+
+            async def fake_run(command: list[str]) -> None:
+                commands.append(command)
+                if command[3:5] == ["worktree", "remove"]:
+                    raise RuntimeError("workspace already absent")
+
+            with mock.patch.object(WorktreeManager, "_run", side_effect=fake_run):
+                await manager.cleanup(
+                    [work_item],
+                    context,
+                    cleanup_enabled=True,
+                    retain_failed_worktrees=False,
+                    run_success=True,
+                    run_has_failures=False,
+                )
+
+        self.assertEqual(len(commands), 2)
+        self.assertEqual(commands[0][3:5], ["worktree", "remove"])
+        self.assertEqual(commands[1][3:5], ["branch", "-D"])
+        self.assertEqual(work_item.metadata["workspace_cleanup_status"], "completed")
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Harden `openclaw_v2/web.py` so history, cleanup, prune, and compare reuse the request-loaded config instead of reopening the config file in background helpers.
- Keep config-disappearance races from turning already-validated requests into `500` responses.
- Harden `main_v2.py` so `_print_preflight()` ignores disappearing, unreadable, or malformed `preflight.json` instead of crashing after a run.
- Harden `openclaw_v2/worktree.py` so cleanup keeps going when `git worktree remove` fails because the workspace disappeared first, and still keeps going when `git branch -D` fails because the branch is already gone.
- Harden Hermes preflight `_check_hermes_runtime()` so a selected probe file disappearing before the read starts is downgraded to a warning instead of crashing preflight.
- Add regressions for config disappearance after initial load on `/api/history/<run>`, `/api/history/<run>/cleanup`, `/api/history/prune`, the CLI preflight report printer, the worktree cleanup race, and the Hermes runtime probe disappearance race.
- Preserve the existing runtime-root binding and housekeeping-token checks.
- Update `PROJECT_STATUS.md` to reflect the new race-hardening slice.

## Verification
- `python3 -m unittest tests.test_preflight.PreflightOpenClawTests.test_hermes_runtime_probe_treats_missing_probe_file_as_warning`
- `python3 -m unittest tests.test_preflight`
- `python3 -m unittest discover -s tests`
- `node --check openclaw_v2/webui/app.js`
- Latest successful GitHub review workflow run for head `34be4f74161bd23eb1a2e6c9330ba95c6b4d5e45`: [OpenClaw Review](https://github.com/crused-fall/Openclaw-AIagent-control/actions/runs/25279395812)

## Reviewer focus
- `main_v2.py` for the CLI preflight report tolerance.
- `openclaw_v2/preflight.py` for the Hermes runtime probe disappearance warning.
- `openclaw_v2/web.py` for the request-scoped config binding and race-hardening helpers.
- `openclaw_v2/worktree.py` for workspace cleanup races.
- `tests/test_preflight.py`, `tests/test_main_v2.py`, `tests/test_web.py`, and `tests/test_worktree.py` for the new disappearance regressions.
- `PROJECT_STATUS.md` for the status snapshot.
