### PR TITLE
Add collect_review resume pipeline

### DIFF
--- a/PROJECT_LOG.md
+++ b/PROJECT_LOG.md
@@ -1,0 +1,245 @@
+# OpenClaw Project Log
+
+更新时间：2026-05-13
+
+## 用途
+
+这份文件用于归档 `Openclaw-AIagent-control` 之前已经做过的阶段工作，把原本分散在 `PROJECT_STATUS.md` 和 `PROJECT_MEMORY.md` 里的历史过程整理成长期日志。
+
+当前三份项目跟踪文件的分工是：
+
+- `PROJECT_STATUS.md`：当前完成度、稳定基线、阻塞项
+- `PROJECT_MEMORY.md`：当前主线目标、目标文件、下一步工作记忆
+- `PROJECT_LOG.md`：完整项目日志、阶段归档、历史验证记录
+
+## 当前项目结论
+
+- 项目主线已经明确切到 `main_v2.py` + `openclaw_v2/` 的 modified scheme-four Mission Control。
+- `openclaw.py` 仍保留为 v1 legacy，但不再代表主线推进方向。
+- GitHub tail-chain、Web UI control room、OpenClaw fallback live 路径、Hermes supervisor/recorder 这些关键子模块都已经做成可用基线。
+- 当前最大的未完成项不是“再加新功能”，而是把默认 `mission_control_default` 的 live 可用性、GitHub 协作尾链复跑稳定性，以及最终角色边界收口到可发布状态。
+- 当前机器上的默认 live 仍会被 `claude_local` 预检挡住；实际可继续的本地 live 入口仍是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
+
+## 项目进展总览
+
+> 这些百分比是按主线目标完成度估算，不是按提交数统计。
+
+| 方向 | 估算进展 | 当前判断 |
+| --- | ---: | --- |
+| v2 Mission Control 主骨架 | 90% | 已经成为仓库主线，CLI / config / planner / orchestrator / artifacts 基本齐全 |
+| 默认 pipeline 骨架 | 85% | `triage -> collect_review` 全链路已成形，dry-run / preflight / diagnose 能用 |
+| GitHub 协作尾链 | 80% | issue / PR / review workflow / resume / recovery hint 已落地，但还缺更稳定的真实端到端复跑 |
+| Web UI control room | 88% | 已能承担本地主控台职责，且安全/校验/历史/健康/usage 面较完整 |
+| OpenClaw 本地接入 | 75% | fallback live 路径可用，但还不是默认统一总控入口 |
+| Hermes supervisor + recorder | 70% | 角色边界已明确，监督/记录链可接入，但不承担 implement |
+| 成本统计 / 自动 fallback / 更细 review-merge 阶段 | 35% | 仍是明确未完成区 |
+| 整体项目完成度 | 78% | 已接近“几乎完成”，但还没到默认主链稳定可发布 |
+
+## 阶段归档
+
+### Phase 0：方向收敛与可行性判断（2026-03-14 ~ 2026-03-16）
+
+这一阶段的核心不是实现功能，而是把项目方向从“多模型 API demo”收敛到“Mission Control 总控层”。
+
+完成的关键动作：
+
+- 明确 OpenClaw 需要以“修改版方案四”推进，而不是继续强化 v1 keyword router。
+- 产出面向 CLI + GitHub + review/supervision 的可行性方案和框架草案。
+- 确认 `main_v2.py` + `openclaw_v2/` 将成为真实主线。
+
+### Phase 1：默认 pipeline 脊柱成形（2026-03-27 ~ 2026-04-02）
+
+这一阶段把默认 pipeline 从概念拉到可执行骨架。
+
+完成的关键动作：
+
+- 引入 GitHub review workflow。
+- 稳定默认 pipeline 的 noop / dirty worktree / missing labels / skipped publish 等分支。
+- 明确加入 `commit_changes`，把“改动提交”从 publish 前置条件里拆成显式步骤。
+- 使用 isolated worktree 承载 implement，避免污染仓库根目录。
+- 补齐 publish blocked 条件：依赖分支缺失、变更未提交、base branch ahead of upstream 等。
+- 保留 committed workspace metadata，为后续 publish / review / cleanup 提供追踪基础。
+
+### Phase 2：OpenClaw / Hermes / 控制台主控面扩展（2026-04-16 ~ 2026-04-30）
+
+这一阶段把项目从“只会跑 pipeline”推进到“可观察、可监督、可切换 agent 变体”的状态。
+
+完成的关键动作：
+
+- 澄清 `github_bridge_smoke` 的边界，避免把 smoke pipeline 误当成完整主链。
+- 引入 Hermes `supervisor + recorder` 变体 pipeline，明确它不接 implement。
+- 建立 Web UI control room，把 CLI / GitHub / health / run history / housekeeping 集中到一个本地入口。
+- 为 `doctor-config` 加回归测试，锁定配置诊断不会误入交互路径。
+- 开始系统性收 GitHub bridge 链接和 Web UI 输入/输出的安全问题。
+
+### Phase 3：Web / API / race hardening（2026-04-29 ~ 2026-05-03）
+
+这一阶段的主题是“让控制台和历史读取在坏输入、坏 JSON、坏编码、目录消失、文件消失时仍然稳住”。
+
+完成的关键动作：
+
+- 补齐 Web API JSON 输入校验：对象体、布尔值、整数、非负数、合法 steps、非空请求。
+- 收紧 repo/config/runtime scope，避免 Web UI 对任意路径做越界清理、历史枚举和健康检查。
+- housekeeping 增加 manifest 范围校验和 confirmation token。
+- 大量处理 run/history/cleanup/compare/preflight/config/worktree 的 race 条件。
+- 安全头覆盖到错误响应；artifact path escape、history compare 输入、cleanup 竞态都补了回归保护。
+
+### Phase 4：GitHub review 恢复链路与 reviewer-facing 输出（2026-05-06 ~ 2026-05-07）
+
+这一阶段把 GitHub tail-chain 从“能跑”推进到“失败时能读懂、稍后能恢复、UI 和导出文案语义一致”。
+
+完成的关键动作：
+
+- `collect_review` failed / action_required / in_progress 会统一生成 `github_failure_kind`、`github_retryable`、`github_recovery_hint`。
+- 非 workflow GitHub 失败也会汇总到 `github.latestFailure`。
+- Web UI compare / recent runs / run detail / bridge copy 会统一显示最新 GitHub failure 和 recovery。
+- 新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`。
+- Web UI Launch Pad 新增 workflow run ref 输入。
+- 增加 `collect_review` polling 窗口，并用真实 smoke 验证可以在同一次 live run 内收敛到 success。
+
+### Phase 5：usage 可视化、默认 live blocker 诊断与 OpenClaw fallback 固化（2026-05-08 ~ 2026-05-12）
+
+这一阶段的主题是两件事：
+
+1. 把 OpenClaw usage 从结果 JSON 提升到控制台里的可读信息。
+2. 把默认 live 的 Claude blocker 和可用 fallback 路径解释清楚。
+
+完成的关键动作：
+
+- Web UI recent runs / run summary / history compare / bridge copy 增加 OpenClaw usage 汇总。
+- 新增 Token Stats 面板，只读 token breakdown，不做 cost 估算。
+- preflight 先做 Claude print-mode 探针，在 triage 前暴露不可用状态。
+- recovery hint 统一指向 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
+- README 和状态文档持续记录 fallback live smoke、no-op tail-chain 行为、当前默认 live blocker。
+
+## 当前可用基线（2026-05-13 存档快照）
+
+### 已经可用
+
+- `main_v2.py` 已是统一控制入口。
+- `config_v2.yaml` + planner/orchestrator/preflight/worktree/artifacts 已形成完整骨架。
+- 默认 pipeline `mission_control_default` 的 step 结构已经固定。
+- GitHub tail-chain 已支持 issue / PR / review workflow / resume / recovery hint / failed jobs 摘要。
+- Web UI control room 已可承担本地主控台职责。
+- `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 已验证为当前机器上的可用 live fallback。
+- Hermes 已稳定在 `supervisor + recorder` 角色，不参与 implement。
+
+### 当前阻塞
+
+- 当前机器上的 `mission_control_default --live` 仍会被 `claude_local` 预检超时或未认证挡住。
+- 默认主链还没有被证明能在当前机器上稳定重复跑完完整 live tail-chain。
+- OpenClaw 还没有被提升成默认统一总控入口。
+- 成本统计、跨层自动 fallback、细化 review/merge 阶段仍未完成。
+
+## 关键验证记录归档
+
+- 2026-05-07：真实 `github_bridge_smoke` live run 证明 `collect_review` 轮询窗口需要加长；随后同一条链路已验证能直接收敛为 success。
+- 2026-05-07：`github_collect_review_resume` 已用真实 workflow run `25504962543` 验证成功。
+- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过。
+- 2026-05-08：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 已完整跑通 triage / implement / review live smoke。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功完成，workflow run `25643659466` 证明当前 review smoke 仍可用。
+- 2026-05-11 ~ 2026-05-12：多次 fallback/no-op smoke 进一步确认：默认 live 仍被 Claude preflight 挡住，但 OpenClaw fallback 仍是当前机器上的可继续入口。
+
+## 完整 Git 历史日志（按提交时间正序）
+
+```text
+2026-03-14 46755f2 Provide OpenClaw feasibility plan
+2026-03-15 068cb93 构建CLI与GitHub框架草案指南
+2026-03-16 505e173 Assess Openclaw v2 changes
+2026-03-27 b5586ba Add OpenClaw review workflow
+2026-03-27 7c1c782 WIP: stabilize openclaw default pipeline
+2026-03-27 0235fd8 Handle noop implement results and dirty worktree preflight
+2026-03-27 488fa54 Handle missing GitHub labels gracefully
+2026-03-27 c08cbbc Allow noop issue follow-up after skipped publish
+2026-03-28 2311070 Guard noop dependency value collection
+2026-03-28 c7a4140 Add orchestrator regression for noop OpenClaw issue follow-up
+2026-03-28 b9c3212 Use ephemeral Codex runs and surface usage limits
+2026-03-28 a94fcd0 Add OpenClaw implement fallback and noop detection
+2026-03-28 7447fde Block publish when no dependency branch is exported
+2026-03-28 8c880a3 Document headless GitHub auth fallback
+2026-03-28 cc5cfec Block publish when dependency changes are uncommitted
+2026-03-28 c66f7f2 Add explicit commit_changes pipeline stage
+2026-03-28 6ec3b3b Use isolated worktrees for OpenClaw implement steps
+2026-03-28 125d15b Preserve OpenClaw branch artifacts in dry-run
+2026-04-02 a1b5115 Track committed workspace metadata
+2026-04-02 7b88e75 Clarify review prompts for isolated worktrees
+2026-04-02 085ff27 Block live publish when base branch is ahead of upstream
+2026-04-16 ab2ace5 Clarify github_bridge_smoke scope
+2026-04-29 2dce486 Add Hermes supervisor and recorder pipeline (#9)
+2026-04-29 98b104a Build Hermes-aware Mission Control control room (#10)
+2026-04-29 45e31cf Add doctor-config CLI regression test (#11)
+2026-04-29 b2343f9 Harden GitHub bridge links and coverage
+2026-04-29 ae34795 Add history file path escape regression
+2026-04-29 76c3e4a Add history compare input regression
+2026-04-30 d24611f Handle invalid JSON in web API handlers
+2026-04-30 b62288a Validate prune keepLatest input
+2026-04-30 45dde83 Require object JSON bodies in web API
+2026-05-01 f7c4f6b Harden dashboard input validation
+2026-05-01 fe49d4d Tighten web task input validation
+2026-05-01 17a0d17 Validate dashboard requests before queueing
+2026-05-01 07b44cc Tighten history compare input validation
+2026-05-01 e84bbae Harden run history JSON handling
+2026-05-01 01eb7b5 Reject negative history prune limits
+2026-05-01 6446d38 Harden run metadata shape handling
+2026-05-01 eced709 Harden health snapshot parsing
+2026-05-01 a7d298a Skip bad bytes in run metadata readers
+2026-05-02 7f8bf31 Harden run metadata race handling
+2026-05-02 27c4269 Harden history compare summaries
+2026-05-02 d27b29a Harden web race handling
+2026-05-02 06f872a Harden cleanup artifact races
+2026-05-02 690d2bd Document cleanup artifact race hardening
+2026-05-02 ae62bf9 Address review comments on web races
+2026-05-02 01a5e89 Harden artifact enumeration races
+2026-05-02 0d73ee9 Harden Hermes preflight env loading
+2026-05-02 8bc9eb1 Harden Hermes preflight config races
+2026-05-02 12aceec Harden Hermes preflight fallback config races
+2026-05-03 594b3a7 Harden config loader fallback races
+2026-05-03 113210b Harden startup config disappearance handling
+2026-05-03 8b0d905 Harden web config race handling
+2026-05-03 ec3df0d Harden CLI preflight report races
+2026-05-03 07f96e2 Harden CLI preflight report shapes
+2026-05-03 12ab877 Harden worktree cleanup races
+2026-05-03 d5811a1 Harden worktree cleanup branch races
+2026-05-03 34be4f7 Harden Hermes runtime probe races
+2026-05-03 3e5cab3 Merge pull request #12 from crused-fall/codex/harden-web-race-handling
+2026-05-03 a315b64 Add Hermes role regression coverage
+2026-05-03 e30ec2a Harden GitHub review workflow summaries
+2026-05-03 072d64e Track project memory and target files
+2026-05-06 f167d2f Propagate review workflow recovery hints
+2026-05-07 d6142a6 Unify GitHub bridge failure recovery view
+2026-05-07 b797966 Surface GitHub failure operators in compare UI
+2026-05-07 10d70bf Expose GitHub failure state in recent runs
+2026-05-07 1a0b44e Surface GitHub failure in run detail
+2026-05-07 701d478 Extend GitHub review poll window
+2026-05-07 cbbb88c Add collect_review resume pipeline
+2026-05-07 72c3d58 Add workflow run ref control to Web UI
+2026-05-07 6870e74 Record resume smoke and verification status
+2026-05-08 74d4851 Add OpenClaw usage summaries to Web UI
+2026-05-08 d703175 Add OpenClaw usage trend to recent runs
+2026-05-08 3608c0f Include OpenClaw usage in bridge copy text
+2026-05-08 58e391e Add Claude CLI preflight probe
+2026-05-08 7da06c6 Record OpenClaw live smoke success
+2026-05-08 e2aaa32 Clarify OpenClaw default implement override
+2026-05-08 f4f25d8 Add Claude preflight recovery hint
+2026-05-08 06c45ec Add OpenClaw fallback hint to README
+2026-05-09 343b525 Record current live fallback status
+2026-05-09 f5cdb19 Record claude_local_isolated live fallback result
+2026-05-09 30e90f9 Clarify Claude isolated fallback diagnostics
+2026-05-09 add9507 Record isolated Claude fallback diagnostics
+2026-05-09 4ddd12e Clarify Claude isolated fallback guidance
+2026-05-10 a0ede8d Surface preflight recovery hints in Web UI
+2026-05-11 ac70fa6 Surface preflight recovery hints in copy surfaces
+2026-05-11 88b8afd Record review workflow validation
+2026-05-11 5c240e3 Record latest review run for PR 13
+2026-05-11 37bbdcf Record fresh live smoke results
+2026-05-11 1d2d1a2 Record fallback tail-chain smoke outcome
+2026-05-11 400ad43 Clarify fallback smoke no-op behavior
+2026-05-11 bca3a03 Record latest smoke clarification
+2026-05-11 3b745a0 Record latest fallback smoke facts
+2026-05-12 d17d0a4 Record latest no-op smoke in docs
+2026-05-12 d4f88ae Record latest default pipeline blocker
+2026-05-12 3440cd0 Record latest override smoke success
+2026-05-12 cc636f7 Revert "Record latest override smoke success"
+2026-05-12 17c4792 feat: add token stats panel to web ui
+2026-05-12 8b1af4b docs: record token stats panel
+```

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -56,6 +56,7 @@
 - 2026-05-08：Web UI run insights 新增 `usage` 聚合层，会从 `summary.json` 汇总 `openclaw_usage` / `openclaw_last_call_usage`，后续可以直接接到成本展示而不用改 summary 结构。
 - 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
+- 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -66,7 +66,7 @@
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功完成，workflow run `25642896608` 证明当前分支的 GitHub review smoke 还能正常收敛。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -66,6 +66,7 @@
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功完成，workflow run `25642896608` 证明当前分支的 GitHub review smoke 还能正常收敛。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-12
+更新时间：2026-05-10
 
 ## 主目标
 
@@ -73,7 +73,6 @@
 - 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
 - 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；`run-20260511T230911Z-6e0886` 复现了 blocker，当前可继续的 live 入口还是 OpenClaw fallback。
-- 2026-05-12：在 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`、`OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router`、`OPENCLAW_AGENT_ID=openclaw-control-ext` 下，`mission_control_default` 的 live smoke `run-20260512T102057Z-4098c0` 已完整跑通默认尾链并让 `openclaw-review.yml` workflow `25728503893` 成功完成；这说明默认主链在 OpenClaw override 下已经能端到端收敛，但当前机器的纯 Claude 默认 live 入口仍然被预检挡住。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -59,6 +59,7 @@
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
+- 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。
@@ -68,9 +69,10 @@
 
 1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
 2. 先决定 Claude CLI 可用性 / auth 这条 live 路径的恢复方式：要么把本机 headless Claude 登录补齐，要么在默认 pipeline 里为 triage / review 选择明确的本地 fallback，避免 live smoke 继续依赖隐式外部状态。
-3. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
-4. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
-5. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
+3. 基于 `mission_control_openclaw_default` 已跑通的结果，判断 OpenClaw 变体是否应该继续承担主力 live 基线，还是仅作为对照路径保留。
+4. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
+5. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
+6. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
 
 ## 记录规则
 

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -63,6 +63,7 @@
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
 - 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
+- 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -67,6 +67,8 @@
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
+- 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
+- 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-10
+更新时间：2026-05-12
 
 ## 主目标
 
@@ -58,6 +58,7 @@
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
+- 2026-05-12：Web UI 新增 Token Stats 面板，会优先展示当前加载 run 的 `openclaw_usage` / `openclaw_last_call_usage`，没有加载 run 时则回退到最近一次 recent run；这个面板只做 token breakdown，不做 cost / rate 估算。
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
 - 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -62,6 +62,7 @@
 - 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
+- 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -57,6 +57,7 @@
 - 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
+- 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -71,6 +71,7 @@
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
 - 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
+- 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -69,6 +69,7 @@
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
 - 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
+- 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-07
+更新时间：2026-05-08
 
 ## 主目标
 
@@ -53,6 +53,9 @@
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
 - 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。
 - 2026-05-07：真实 `github_bridge_smoke` live run 证明原来的 `collect_review` 轮询窗口太短；默认 polling 已从 12 秒提高到约 30 秒，并用真实 run `run-20260507T151929Z-5962a5` / workflow `25504962543` 验证同次 live run 可直接收敛为 success。
+- 2026-05-08：Web UI run insights 新增 `usage` 聚合层，会从 `summary.json` 汇总 `openclaw_usage` / `openclaw_last_call_usage`，后续可以直接接到成本展示而不用改 summary 结构。
+- 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
+- 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -33,6 +33,7 @@
 - `README.md`
 - `tests/test_github_executor.py`
 - `tests/test_web.py`
+- `openclaw_v2/webui/index.html`
 - `tests/test_webui_static.py`
 
 ## 最近进展
@@ -45,6 +46,7 @@
 - 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
 - 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
 - 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
+- 2026-05-07：Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带进 task payload 和 readiness gate，避免 resume 流程还要手动改请求体。
 - 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
 - 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -46,6 +46,8 @@
 - 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
 - 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
 - 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
+- 2026-05-07：重新跑通 `github_collect_review_resume` live smoke，workflow run `25504962543` 仍然可直接收敛为 success。
+- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过。
 - 2026-05-07：Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带进 task payload 和 readiness gate，避免 resume 流程还要手动改请求体。
 - 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-10
+更新时间：2026-05-12
 
 ## 主目标
 
@@ -73,6 +73,7 @@
 - 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
 - 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；`run-20260511T230911Z-6e0886` 复现了 blocker，当前可继续的 live 入口还是 OpenClaw fallback。
+- 2026-05-12：在 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`、`OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router`、`OPENCLAW_AGENT_ID=openclaw-control-ext` 下，`mission_control_default` 的 live smoke `run-20260512T102057Z-4098c0` 已完整跑通默认尾链并让 `openclaw-review.yml` workflow `25728503893` 成功完成；这说明默认主链在 OpenClaw override 下已经能端到端收敛，但当前机器的纯 Claude 默认 live 入口仍然被预检挡住。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -58,6 +58,7 @@
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
+- 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。
@@ -66,9 +67,10 @@
 ## 下一步候选
 
 1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
-2. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
-3. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
-4. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
+2. 先决定 Claude CLI 可用性 / auth 这条 live 路径的恢复方式：要么把本机 headless Claude 登录补齐，要么在默认 pipeline 里为 triage / review 选择明确的本地 fallback，避免 live smoke 继续依赖隐式外部状态。
+3. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
+4. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
+5. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
 
 ## 记录规则
 

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -59,6 +59,7 @@
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
+- 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
@@ -68,7 +69,7 @@
 ## 下一步候选
 
 1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
-2. 先决定 Claude CLI 可用性 / auth 这条 live 路径的恢复方式：要么把本机 headless Claude 登录补齐，要么在默认 pipeline 里为 triage / review 选择明确的本地 fallback，避免 live smoke 继续依赖隐式外部状态。
+2. Claude CLI 不可用时，优先把 live 路径切到已经验证过的 OpenClaw fallback，而不是继续把时间耗在默认 triage 超时上。
 3. 基于 `mission_control_openclaw_default` 已跑通的结果，判断 OpenClaw 变体是否应该继续承担主力 live 基线，还是仅作为对照路径保留。
 4. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
 5. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-08
+更新时间：2026-05-09
 
 ## 主目标
 
@@ -61,6 +61,7 @@
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
 - 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
+- 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -70,6 +70,7 @@
 - 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
+- 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -72,6 +72,7 @@
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
 - 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
+- 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；`run-20260511T230911Z-6e0886` 复现了 blocker，当前可继续的 live 入口还是 OpenClaw fallback。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -65,6 +65,7 @@
 - 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
+- 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-09
+更新时间：2026-05-10
 
 ## 主目标
 
@@ -64,6 +64,7 @@
 - 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
 - 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
+- 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -22,11 +22,15 @@
 - `config_v2.yaml`
 - `main_v2.py`
 - `openclaw_v2/web.py`
+- `openclaw_v2/config.py`
 - `openclaw_v2/webui/app.js`
 - `openclaw_v2/executors/github.py`
 - `openclaw_v2/executors/openclaw.py`
 - `openclaw_v2/preflight.py`
 - `openclaw_v2/orchestrator.py`
+- `config_v2.yaml`
+- `main_v2.py`
+- `README.md`
 - `tests/test_github_executor.py`
 - `tests/test_web.py`
 - `tests/test_webui_static.py`
@@ -38,6 +42,9 @@
 - 2026-05-07：非 workflow 的 GitHub 失败现在也会汇总为 `github.latestFailure`，不再只靠 workflow 专属视图承载恢复提示。
 - 2026-05-07：Web UI 的 Bridge state 和导出文案现在会优先显示最新 GitHub 失败的恢复路径，避免 `draft_pr` / `update_issue` / `dispatch_review` 失败被“pending”文案掩盖。
 - 2026-05-07：GitHub bridge cards 现在即使拿不到 issue / PR / workflow 引用，也会为失败步骤保留 operator 卡片，并显示 step summary、failure kind 和 recovery hint。
+- 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
+- 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
+- 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
 - 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
 - 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -66,7 +66,7 @@
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功完成，workflow run `25643659466` 证明当前分支的 GitHub review smoke 还能正常收敛；README 也补了 `github_bridge_smoke` 的 no-op tail-chain 说明。
 - 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-12
+更新时间：2026-05-13
 
 ## 主目标
 
@@ -11,85 +11,54 @@
 
 ## 当前主线
 
-- 稳定 GitHub bridge 的结果诊断、review 透传、失败恢复和 reviewer-facing 输出。
-- 稳定本地 Web UI control room 的安全边界、可观测性和 run/history/health 协作体验。
-- 持续校准 `config_v2.yaml` 中的 pipeline、assignment、managed agent 和 preflight 约束。
+- 继续稳定 GitHub bridge 的结果诊断、review 透传、失败恢复和 reviewer-facing 输出。
+- 继续稳定本地 Web UI control room 的安全边界、可观测性和 run/history/health 协作体验。
+- 继续校准 `config_v2.yaml` 中的 pipeline、assignment、managed agent 和 preflight 约束。
+- 继续把默认主链和 OpenClaw fallback 的角色边界记录清楚，避免误把当前 fallback 成功当成默认主链已经完成。
 
 ## 当前目标文件
 
 - `PROJECT_STATUS.md`
 - `PROJECT_MEMORY.md`
-- `config_v2.yaml`
-- `main_v2.py`
-- `openclaw_v2/web.py`
-- `openclaw_v2/config.py`
-- `openclaw_v2/webui/app.js`
-- `openclaw_v2/executors/github.py`
-- `openclaw_v2/executors/openclaw.py`
-- `openclaw_v2/preflight.py`
-- `openclaw_v2/orchestrator.py`
+- `PROJECT_LOG.md`
 - `config_v2.yaml`
 - `main_v2.py`
 - `README.md`
+- `openclaw_v2/web.py`
+- `openclaw_v2/config.py`
+- `openclaw_v2/preflight.py`
+- `openclaw_v2/orchestrator.py`
+- `openclaw_v2/executors/github.py`
+- `openclaw_v2/executors/openclaw.py`
+- `openclaw_v2/webui/index.html`
+- `openclaw_v2/webui/app.js`
 - `tests/test_github_executor.py`
 - `tests/test_web.py`
-- `openclaw_v2/webui/index.html`
 - `tests/test_webui_static.py`
 
-## 最近进展
+## 本次归档结果
 
-- 2026-05-06：`collect_review` 的 workflow 失败 / action_required / in-progress 状态现在会带出统一的 `github_failure_kind`、`github_retryable` 和 `github_recovery_hint`。
-- 2026-05-06：GitHub review workflow 的恢复提示现在会回流到 run insights，并显示在 Web UI 的 bridge 文案、run summary、issue update 和 PR note 里。
-- 2026-05-07：非 workflow 的 GitHub 失败现在也会汇总为 `github.latestFailure`，不再只靠 workflow 专属视图承载恢复提示。
-- 2026-05-07：Web UI 的 Bridge state 和导出文案现在会优先显示最新 GitHub 失败的恢复路径，避免 `draft_pr` / `update_issue` / `dispatch_review` 失败被“pending”文案掩盖。
-- 2026-05-07：GitHub bridge cards 现在即使拿不到 issue / PR / workflow 引用，也会为失败步骤保留 operator 卡片，并显示 step summary、failure kind 和 recovery hint。
-- 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
-- 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
-- 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
-- 2026-05-07：重新跑通 `github_collect_review_resume` live smoke，workflow run `25504962543` 仍然可直接收敛为 success。
-- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过。
-- 2026-05-07：Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带进 task payload 和 readiness gate，避免 resume 流程还要手动改请求体。
-- 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
-- 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
-- 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。
-- 2026-05-07：真实 `github_bridge_smoke` live run 证明原来的 `collect_review` 轮询窗口太短；默认 polling 已从 12 秒提高到约 30 秒，并用真实 run `run-20260507T151929Z-5962a5` / workflow `25504962543` 验证同次 live run 可直接收敛为 success。
-- 2026-05-08：Web UI run insights 新增 `usage` 聚合层，会从 `summary.json` 汇总 `openclaw_usage` / `openclaw_last_call_usage`，后续可以直接接到成本展示而不用改 summary 结构。
-- 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
-- 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
-- 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
-- 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
-- 2026-05-12：Web UI 新增 Token Stats 面板，会优先展示当前加载 run 的 `openclaw_usage` / `openclaw_last_call_usage`，没有加载 run 时则回退到最近一次 recent run；这个面板只做 token breakdown，不做 cost / rate 估算。
-- 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
-- 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
-- 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
-- 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
-- 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
-- 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
-- 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
-- 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功完成，workflow run `25643659466` 证明当前分支的 GitHub review smoke 还能正常收敛；README 也补了 `github_bridge_smoke` 的 no-op tail-chain 说明。
-- 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
-- 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
-- 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
-- 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
-- 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
-- 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；`run-20260511T230911Z-6e0886` 复现了 blocker，当前可继续的 live 入口还是 OpenClaw fallback。
-- 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
-- 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
-- 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。
-- 2026-05-03：Web UI 安全头已覆盖错误响应，不再只覆盖成功响应。
+- 历史阶段过程已从当前状态文件里抽离，集中归档到 `PROJECT_LOG.md`。
+- `PROJECT_STATUS.md` 已收敛回“完成度 + 稳定基线 + 阻塞项”。
+- `PROJECT_MEMORY.md` 只保留当前主线目标、目标文件和下一步判断，不再承担完整历史日志职责。
+
+## 当前关键事实
+
+- 当前机器上的 `mission_control_default --live` 仍会被 `claude_local` 预检挡住。
+- 当前机器上的可继续 live 入口仍是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
+- `github_collect_review_resume`、`github_bridge_smoke`、Web UI Token Stats、GitHub recovery surfaces 都已经进入“已做完并应保持稳定”的归档区域。
+- 后续新增工作不应再把 `PROJECT_STATUS.md` / `PROJECT_MEMORY.md` 堆成长流水账；阶段事实优先沉到 `PROJECT_LOG.md`。
 
 ## 下一步候选
 
-1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
-2. Claude CLI 不可用时，优先把 live 路径切到已经验证过的 OpenClaw fallback，而不是继续把时间耗在默认 triage 超时上。
-3. 基于 `mission_control_openclaw_default` 已跑通的结果，判断 OpenClaw 变体是否应该继续承担主力 live 基线，还是仅作为对照路径保留。
-4. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
-5. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
-6. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
+1. 继续做默认 `mission_control_default` 的真实 live 验证，判断它在当前机器上究竟是“待修复默认入口”还是“需要正式让位给 OpenClaw fallback”。
+2. 继续做 GitHub 尾链的真实 end-to-end 验证，尤其是 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 的重复运行稳定性。
+3. 若默认主链短期内仍受 Claude 环境限制，就把 OpenClaw fallback 的 operator 语义、文档和 UI 提示进一步固定下来。
+4. 在默认 pipeline 稳定前，不扩 Hermes 到 `implement`，也不急着把 OpenClaw 命名上提前升级成已经完成的默认总控。
 
 ## 记录规则
 
 - 只要出现实质性阶段推进，更新 `PROJECT_STATUS.md`。
 - 只要当前焦点、目标文件或下一步判断变化，更新 `PROJECT_MEMORY.md`。
-- 如果变更直接影响主线判断，两个文件都更新。
+- 只要需要保留完整历史过程、验证序列或阶段归档，更新 `PROJECT_LOG.md`。
+- 如果变更直接影响主线判断，三个文件可以一起更新，但 `PROJECT_STATUS.md` / `PROJECT_MEMORY.md` 不再堆长流水账。

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,7 +41,7 @@
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功跑完，workflow run `25643659466` 已验证当前分支的 GitHub review smoke 仍然可用；README 也补了 `github_bridge_smoke` 的 no-op tail-chain 说明
 - 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -134,6 +134,7 @@
 - Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
 - Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
 - Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，便于快速看出最近 token 消耗是上升、下降还是持平
+- Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，桥接输出和可视面板的语义已经对齐
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,198 +1,76 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-12
+更新时间：2026-05-13
 
 ## 当前记录入口
 
-- 阶段性状态与已完成能力：`PROJECT_STATUS.md`
-- 当前目标、目标文件与下一步工作记忆：`PROJECT_MEMORY.md`
+- `PROJECT_STATUS.md`：当前完成度、稳定基线、阻塞项
+- `PROJECT_MEMORY.md`：当前主线目标、目标文件、下一步工作记忆
+- `PROJECT_LOG.md`：完整项目日志与历史归档
 
-## 当前主线目标
+## 项目完成度快照
 
-- 稳定默认 `mission_control_default` pipeline
-- 继续补 GitHub bridge 的结果诊断、review 透传和失败恢复
-- 继续收敛本地 Web UI control room 的安全边界与协作可读性
-- 保持 Hermes 只做 `supervisor + recorder`，不接 `implement`
+> 这些百分比是按主线目标估算，不是按提交量统计。
 
-## 当前阶段
+| 方向 | 估算进展 | 当前状态 | 说明 |
+| --- | ---: | --- | --- |
+| v2 Mission Control 主骨架 | 90% | 稳定 | `main_v2.py` + `openclaw_v2/` 已成为真实主线 |
+| 默认 pipeline 骨架 | 85% | 稳定但未完全收口 | `triage -> collect_review` 结构完整，dry-run / preflight / diagnose 能用 |
+| GitHub 协作尾链 | 80% | 可用 | issue / PR / review workflow / resume / recovery hint 已落地 |
+| Web UI control room | 88% | 可用 | 已覆盖 launch / history / compare / health / bridge / housekeeping / token stats |
+| OpenClaw 本地接入 | 75% | 可用但非默认 | fallback live 路径可跑，尚未成为默认总控入口 |
+| Hermes supervisor + recorder | 70% | 可用但受限 | triage / review / record_summary 可接，明确不承担 implement |
+| 成本统计 / 自动 fallback / 更细 review-merge 阶段 | 35% | 未完成 | 属于当前主要剩余工作 |
+| 整体项目完成度 | 78% | 接近收口 | 已接近“几乎完成”，但还没到默认主链稳定可发布 |
 
-项目已经从“多模型 API 路由原型”进入“修改版方案四 Mission Control 骨架”阶段。
+## 当前主线判断
 
-这意味着：
+- 项目已经从“多模型 API demo”转成“以 CLI + GitHub workflow 为中心的 Mission Control”。
+- `openclaw.py` 仍保留，但只代表 v1 legacy；主线实现已经是 `main_v2.py` + `openclaw_v2/`。
+- 当前最重要的不是再扩新 agent，而是把默认 `mission_control_default` 的 live 稳定性、GitHub 协作尾链复跑性和角色边界收口清楚。
+- OpenClaw 当前已经是可靠 fallback 执行器，但还不是默认统一总控入口。
 
-- `openclaw.py` 仍可运行，但只代表 v1 legacy
-- 核心演进方向已经转向 `main_v2.py` + `openclaw_v2/`
-- OpenClaw 已进入执行层与受控 agent 体系，但还没有成为默认统一总控入口
+## 当前稳定基线
 
-## 已完成
+### 已完成并可复用的能力
 
-### Control Layer
+- `main_v2.py` 统一入口、`--doctor-config`、`--diagnose-plan`、`--preflight-only`、`--web`
+- assignment / managed-agent / capability / fallback 解析链
+- `commit_changes` 显式 stage + implement worktree / branch 复用
+- GitHub issue / PR / workflow / review workflow / resume / recovery hint 回流
+- Web UI control room：launch pad、readiness gate、health、recent runs、history compare、GitHub bridge、housekeeping、token stats
+- Web / history / cleanup / config / preflight / worktree 的大规模 race hardening
+- Hermes `supervisor + recorder` 变体 pipeline
+- OpenClaw fallback live 入口：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 
-- `main_v2.py` 已可作为统一入口
-- 支持 `--steps`、`--request`、`--live`、`--preflight-only`
-- 支持 `--list-managed-agents`、`--doctor-config`、`--diagnose-plan`
-- `--doctor-config` 已有 CLI 回归测试并合并到 main，锁定配置诊断路径不会误进入交互模式
-- CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
-- CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
-- live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
-- 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
-- 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
-- 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
-- 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
-- 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
-- 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功跑完，workflow run `25643659466` 已验证当前分支的 GitHub review smoke 仍然可用；README 也补了 `github_bridge_smoke` 的 no-op tail-chain 说明
-- 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
-- 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
-- 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
-- 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
-- 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
-- 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；最新 live smoke `run-20260511T230911Z-6e0886` 复现了这个 blocker，并继续给出 OpenClaw fallback 提示
-- 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
-- 支持 `--web` 本地 Mission Control 控制台
-- live 运行时会输出 step 级 progress
+### 当前机器上的已知事实
 
-### Orchestration Layer
+- `mission_control_default --live` 仍会在 `claude_local` 预检处被挡住。
+- 当前可继续的本地 live 入口仍是 OpenClaw fallback，而不是默认 Claude 路径。
+- `github_collect_review_resume` 与 `github_bridge_smoke` 已有真实成功记录。
 
-- 配置驱动 pipeline（已支持继承 / 覆盖 / remove_steps 组合）
-- assignment 分配层
-- managed-agent registry
-- capability / fallback 解析
-- assignment failure -> blocked policy
-- 依赖调度
-- worktree 隔离
-- artifacts 落盘
-- blocked / failed / skipped 区分
+## 当前阻塞项
 
-### Execution Layer
+1. 默认 `mission_control_default --live` 还没有在当前机器上形成稳定可复跑的完整闭环。
+2. GitHub 协作尾链虽然已经可用，但还需要更多真实 end-to-end 验证来证明“失败可解释、恢复可继续、重复运行不飘”。
+3. OpenClaw 与 Hermes 的最终角色边界虽然大方向已定，但“OpenClaw 何时升级成默认总控入口”还未决。
+4. 成本统计、自动 fallback、更细 review / merge 审核阶段仍未完成。
 
-- CLI 执行层
-- OpenClaw 本地执行层
-- GitHub 执行层
-- 受控 agent 池：Claude / Gemini / Codex / Cursor / OpenClaw
-- GitHub issue / PR / workflow run refs 回流
-- `dispatch_review -> collect_review` workflow 状态回流已落地
-- 新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可直接回流已有 workflow run 而不重新触发 `dispatch_review`
-- `collect_review` resume 现在会保留外部注入的 workflow run ref，并在 prompt / GitHub workflow_view 命令里一致使用
-- 已用真实 live run `25504962543` 验证 `github_collect_review_resume` 可以直接收敛为 success
-- 2026-05-07：重新跑通 `github_collect_review_resume` live smoke，workflow run `25504962543` 仍能直接收敛为 success
-- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过，当前基线可继续作为收口底座
-- `collect_review` 已支持 failed jobs 摘要回流
-- Web UI 的 run summary / issue update / PR note 现在也会回流 review workflow 的 conclusion 和 failed jobs，方便直接把异步检查结果转成可读结论
-- `collect_review` 在 workflow failed / action_required / in_progress 等状态下，现在也会统一带出 `github_failure_kind`、`github_retryable` 和 `github_recovery_hint`
-- Web UI 的 GitHub bridge、run summary、issue update 和 PR note 现在也会显示 review recovery 提示，便于协作方直接采取下一步动作
-- 非 workflow 的 GitHub 失败现在也会汇总成 `github.latestFailure`，供 Web UI 和导出文案统一消费
-- Web UI 的 Bridge state 现在会优先显示最新 GitHub 失败，而不是把 `draft_pr` / `dispatch_review` 之类的真实失败误表述成“pending”
-- 新增 `github_bridge_smoke` pipeline，可绕过本地 `triage/implement/review` 单独验证 GitHub review workflow
-- Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带入 task payload 和 readiness gate，减少手动改请求体的需要
-- `collect_review` 已支持约 30 秒的短轮询等待，减少 workflow 刚触发时立即返回 `queued` 的手工重跑
-- 2026-05-07 已用真实 `github_bridge_smoke` live run 验证更长 polling 窗口：workflow `25504962543` 在同一次 run 内成功从 dispatch 收敛到 collect success
-- 本地 CLI executor 已有超时护栏，`claude/codex` 长时间无响应时不会再无限挂住 run
-- GitHub 步骤 CLI 会打印 `github:` 摘要
-- GitHub bridge 的失败会分类为 auth / repository / workflow / reference / network / unknown
-- GitHub 失败结果会保留 `stderr`、retryability 和恢复提示
-- GitHub bridge 的 `repository_unavailable` / `workflow_missing` 失败分支已补上回归测试，和现有 auth / permission / reference / network 路径一起覆盖主要失败形态
-- GitHub bridge 面板里的 repo / workflow 外链也已统一走 `safeExternalUrl`，避免把非 http(s) URL 直接挂到 `href`
-- GitHub bridge cards 现在即使拿不到 issue / PR / workflow 引用，也会为失败步骤保留 operator 卡片，并带出 summary / failure kind / recovery hint
-- GitHub bridge 已支持显式配置的网络类自动重试
-- GitHub repo 已支持显式开启的 `origin` fallback
-- `gh issue create` 如果因为仓库里缺少 labels 失败，会自动去掉 labels 重试一次，并把被忽略的 labels 回写到结果
-- GitHub bridge state 现在会同步写入 run summary、issue update 和 PR note，方便协作方直接看到最新桥接状态
-- `implement` 为 no-op 且 `sync_issue` 已成功时，`update_issue` 现在允许继续执行 issue 收尾；PR / workflow 尾链仍保持跳过
-- 主线已新增显式 `commit_changes` 步骤，用于在 `review` 后、`publish_branch` 前提交实现工作区里的改动
-- `commit_changes` 会复用实现步骤的 workspace 和分支，而不是回落到仓库根目录
-- `commit_changes` 现在会保留提交前的变更文件列表，并明确记录 `changes_committed` / `head_commit`
-- 只有当改动被提交为干净 commit 后，`publish_branch` 才会继续；否则继续明确 `blocked`
+## 已归档的阶段性工作
 
-### Supervision Layer
+下列历史过程已经转存到 `PROJECT_LOG.md`，不再继续堆在当前状态文件里：
 
-- preflight
-- review step
-- run summary
-- blocked 原因透传
-- `first_blocked` 根因摘要
-- 本地 Web UI 已具备 readiness gate、run compare、artifact browser、health snapshot（含最近 preflight 摘要与来源）、GitHub bridge 总览状态卡和 housekeeping 入口
-- Web UI 的健康面板在渠道数据为空时会保守显示 warning，不再误报 passed
-- Web UI 的 repo/config 作用域已默认收紧到启动时绑定的仓库，避免页面层面对任意路径做历史清理和健康检查
-- housekeeping 清理已改为校验 manifest 的 repo/worktree/branch 范围，防止 run 产物被篡改后越界删除其他仓库对象
-- housekeeping 危险操作已要求当前 dashboard 会话携带服务端确认 token，降低绕过前端弹窗直接调用接口的风险
-- Web UI 对 repo 内替代配置的支持已进一步收紧：允许调整 pipeline/assignment，但不允许改写 dashboard 绑定的 artifacts/worktrees roots
-- Web UI 的安全头现在覆盖 4xx / 5xx 响应，未捕获异常会回落到干净的内部错误响应
-- Web UI 的 artifact file 预览现在会拒绝逃逸 run 目录的路径，避免通过 `../` 之类的相对路径越界读取
-- Web UI 的 history compare 接口现在会拒绝非 list / 非字符串项 / 非恰好两个 / 非不同 run 的 `runIds` 请求，避免比较入口静默接受歧义输入
-- Web API 的 JSON 入口现在会把坏 JSON 统一转换成 `400 Invalid JSON body.`，不再让解析错误冒泡成 `500`
-- Web UI 的 run history / recent runs 读取现在会把损坏、非对象、或嵌套 `plan/results` 形状异常的 run 元数据做保守降级处理；损坏的 `preflight.json` 会按缺失处理，避免浏览历史时炸出 `500`
-- Web UI 的 health snapshot 现在会对 `openclaw health --json` 的 `channelOrder` / `channels` / `agents` / `defaultAgentId` 做保守解析，避免健康页被坏 payload 拖成 `500`
-- Web UI 的 recent runs / cleanup manifest 读取现在也会跳过坏字节输入，避免 `summary.json` / workspace manifest 的编码错误拖垮页面
-- Web UI 的 recent runs / history 读取现在能容忍 `summary.json` 在扫描或读取间消失，避免竞争条件把页面拖成 `500`
-- Web UI 的 history / cleanup / prune 现在会复用请求内已解析的 config，不再在后台线程里二次打开配置文件；这样 config 在请求中途消失时，不会把已经开始的历史读取或清理拖成 `500`
-- Web UI 的 history 文件列表和单文件读取现在也会容忍文件在 size/stat 阶段消失，避免 artifact browser 的竞态把页面拖成 `500`
-- Web UI 的 recent runs / housekeeping prune 现在也会跳过在排序阶段消失的 run 目录，避免目录级竞态把页面拖成 `500`
-- Web UI 的 history 详情页现在也会把 run 目录在更新时间戳阶段消失收敛成 404，避免目录级竞态冒成 `500`
-- Web UI 的 recent runs 现在也会把 `preflight.json` 在读取时消失收敛成缺失预检，避免首页因为预检竞态冒成 `500`
-- Web UI 的 cleanup manifest 读取现在也会跳过在读取时消失的 workspace manifest，避免 housekeeping 因竞态冒成 `500`
-- Web UI 的 cleanup artifact 删除现在也会把 run 目录在删除时消失收敛成已缺失，不再把 housekeeping 因竞态拖成 `500`
-- Web UI 的 artifact file 预览在 stat 消失时会保留原始大小，不再把截断文件误报成 limit 大小
-- Web UI 的 cleanup artifact 删除在真实 OSError 下会返回 failure 记录，不再伪装成 skipped
-- Web UI 的 history 文件枚举现在会把 artifact tree glob 失败收敛成空列表，不再把目录级竞态顶成 `404`
-- Web UI 的 cleanup manifest 枚举现在会把 workspace glob 失败收敛成空列表，不再把 manifest 竞态顶成 `404`
-- Worktree cleanup 现在会把 `git worktree remove` 在 workspace 已经消失时的错误当成可恢复竞态，并把后续 `git branch -D` 在分支已不存在时的错误也视作可恢复，不再因为 cleanup 对象被别的流程先清掉就中断整段 cleanup
-- Hermes preflight 的 `.env` 读取现在也会把文件在 exists/open 之间消失收敛成空值，不再把 Hermes 前置检查拖成异常
-- Hermes preflight 的 `config.yaml` 读取现在也会把文件在 exists/open 之间消失收敛成空配置，不再把 Hermes 前置检查拖成异常；这条也覆盖 PyYAML 和 Ruby fallback 解析路径
-- Hermes runtime probe 现在也会把 probe 文件在选中后、读出前消失收敛成 warning，不再把 Hermes 前置检查拖成异常
-- 配置加载器的 Ruby fallback 现在会把“文件在读取时消失”统一成 `FileNotFoundError`，避免调用方把同一个竞态误报成 YAML 解析失败；判定依据是文件当前是否仍然存在，而不是 Ruby stderr 文本
-- Web UI 的历史与概览里，`success` / `dry_run` 这类状态位现在只认真正的 JSON 布尔值，字符串值不再被误报为 `true`
-- Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
-- Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`
-- Web UI 的 history compare 现在也会显示 `latestFailureChanged` 和左右 run 的 `latestFailures`，方便直接判断 GitHub 失败根因是否已经变化
-- Web UI 的 run insights 现在新增 `usage` 聚合层，会从 `summary.json` 里汇总 `openclaw_usage` / `openclaw_last_call_usage`，为后续成本展示打底
-- Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
-- Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
-- Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，便于快速看出最近 token 消耗是上升、下降还是持平
-- Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，桥接输出和可视面板的语义已经对齐
-- Web UI 现在新增 Token Stats 面板，会直接读取当前加载 run 或最近一次 recent run 的 `openclaw_usage` / `openclaw_last_call_usage`，用 token 汇总和 breakdown 辅助看运行态，不再只靠输出区里的单行 usage 文案
-- Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
-- Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
-- Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报
-- Web API 的任务创建现在会拒绝非布尔的 `live`，避免字符串值误入 live 模式
-- Web API 的任务创建现在会严格校验 `steps` 形状，避免非字符串列表项进入后台执行
-- Web API 的任务创建现在会在入队前拒绝空请求文本和未知 step id，避免先返回 `202` 再异步失败
-- Web UI 的 bootstrap 接口现在会把未知 pipeline override 直接拒绝为 `400`，不再让首页请求落成 `500`
-- Web API 的 housekeeping cleanup / prune 现在会拒绝非布尔的 `removeWorktrees` / `removeArtifacts`，避免字符串值被误判为 `true`
-- Web UI 的 history prune 接口现在会拒绝非整数 `keepLatest`，避免无效保留策略输入漏成 `500`
-- Web API 的 history prune 现在也会拒绝布尔型 `keepLatest`，避免 `true` 被误当成 `1`
-- Web API 的 history prune 现在还会拒绝负数 `keepLatest`，避免错误输入被静默钳成 `0` 后误删全部历史
-- Web API 的 JSON 入口现在还会拒绝非对象 JSON body，避免数组 / 标量 payload 触发 handler 内部异常
+- 2026-03-14 ~ 2026-03-16：方向收敛和 v2 可行性判断
+- 2026-03-27 ~ 2026-04-02：默认 pipeline 脊柱、worktree、commit/publish 约束
+- 2026-04-16 ~ 2026-04-30：OpenClaw / Hermes / Web UI control room 扩展
+- 2026-04-29 ~ 2026-05-03：Web / API / race / scope / safety hardening
+- 2026-05-06 ~ 2026-05-07：GitHub recovery / resume / reviewer-facing 输出
+- 2026-05-08 ~ 2026-05-12：usage 面板、Token Stats、Claude blocker 与 OpenClaw fallback 记录
 
-## 部分完成
+## 下一阶段验收线
 
-- 任务拆分仍然以配置驱动 pipeline 为主，已经支持 pipeline 继承 / 覆盖 / remove_steps 组合，planner 也已开始按依赖关系排序，但还不是智能动态 planner
-- OpenClaw 接入骨架已落地，但目前只安全接到 `triage` 变体 pipeline
-- OpenClaw 已验证“仓库外 workspace + repo 绝对路径 handoff”可运行，当前已有 `mission_control_openclaw_triage` 和 `mission_control_openclaw_default` 两条变体 pipeline；后者已在本机用 `openclaw_builder` 跑通 triage / implement / review live smoke
-- Hermes 已作为本机 `supervisor + recorder` 接入，新增 `mission_control_hermes_supervised` 变体 pipeline，但不承担 `implement`
-- 当前分支上的 Web UI control room 已把 CLI / GitHub / Hermes / OpenClaw 的运行态集中到一个本地面板里
-- `Gemini` 和 `Cursor` 已进入受控 agent 注册表，但还没进入默认 assignment
-- 当前 fallback 仍是静态配置回退，不是实时在线调度
-- live 模式下已默认禁止 fallback managed agent 静默执行
-- GitHub 当前仍是 `gh` bridge，不是 native agent / MCP 编排
-- GitHub 缺少 issue / PR / branch 引用时会被标记为 `blocked`
-- `workflow_dispatch` 已会在 preflight 检查本地 workflow 文件是否存在
-- GitHub 自动重试默认仍是关闭状态
-- GitHub repo 的 `origin` fallback 当前默认已开启
-- `doctor-config` 已覆盖 GitHub runtime retry、GitHub profile action / workflow 配置，以及 pipeline 依赖引用 / 循环校验
-- 真实正向 live 闭环仍取决于外部 agent 环境是否可用，例如 Claude/Codex/OpenClaw/GitHub 权限与配额
+项目要进入“接近完成”的收口状态，至少还需要满足三条：
 
-## 未完成
-
-- OpenClaw 成为默认统一总控入口
-- 成本统计
-- 跨层自动 fallback
-- 更细的 review / merge 审核阶段
-
-## 建议优先级
-
-1. 继续稳定默认 `mission_control_default` pipeline
-2. 决定 OpenClaw 什么时候从变体执行器升级成默认控制入口
-3. 决定哪些 step 默认由 Claude / Codex 继续承担，哪些开始尝试切到 Gemini / Cursor / OpenClaw
-4. 继续补 GitHub bridge 的结果诊断、review 透传和失败恢复
-5. 再考虑真正的动态 planner、fallback 和成本控制
+1. 默认 pipeline 能稳定复跑，或明确宣布 OpenClaw fallback 成为当前机器上的默认可运行入口。
+2. GitHub 尾链在真实 workflow / issue / PR / review 场景下继续验证，且失败结果对人可读、可恢复。
+3. Web UI 继续作为真实运营控制台，而不是只停留在演示面。

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -35,6 +35,7 @@
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
+- 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -57,6 +57,9 @@
 - 受控 agent 池：Claude / Gemini / Codex / Cursor / OpenClaw
 - GitHub issue / PR / workflow run refs 回流
 - `dispatch_review -> collect_review` workflow 状态回流已落地
+- 新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可直接回流已有 workflow run 而不重新触发 `dispatch_review`
+- `collect_review` resume 现在会保留外部注入的 workflow run ref，并在 prompt / GitHub workflow_view 命令里一致使用
+- 已用真实 live run `25504962543` 验证 `github_collect_review_resume` 可以直接收敛为 success
 - `collect_review` 已支持 failed jobs 摘要回流
 - Web UI 的 run summary / issue update / PR note 现在也会回流 review workflow 的 conclusion 和 failed jobs，方便直接把异步检查结果转成可读结论
 - `collect_review` 在 workflow failed / action_required / in_progress 等状态下，现在也会统一带出 `github_failure_kind`、`github_retryable` 和 `github_recovery_hint`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-08
+更新时间：2026-05-09
 
 ## 当前记录入口
 
@@ -36,6 +36,7 @@
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
 - 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
+- 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,6 +41,7 @@
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功跑完，workflow run `25642896608` 已验证当前分支的 GitHub review smoke 仍然可用
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -44,6 +44,7 @@
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
 - 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
+- 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-09
+更新时间：2026-05-10
 
 ## 当前记录入口
 
@@ -39,6 +39,7 @@
 - 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
+- 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -46,6 +46,7 @@
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
 - 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
+- 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -35,6 +35,7 @@
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
+- 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 
@@ -153,7 +154,7 @@
 
 - 任务拆分仍然以配置驱动 pipeline 为主，已经支持 pipeline 继承 / 覆盖 / remove_steps 组合，planner 也已开始按依赖关系排序，但还不是智能动态 planner
 - OpenClaw 接入骨架已落地，但目前只安全接到 `triage` 变体 pipeline
-- OpenClaw 已验证“仓库外 workspace + repo 绝对路径 handoff”可运行，当前已有 `mission_control_openclaw_triage` 和 `mission_control_openclaw_default` 两条变体 pipeline
+- OpenClaw 已验证“仓库外 workspace + repo 绝对路径 handoff”可运行，当前已有 `mission_control_openclaw_triage` 和 `mission_control_openclaw_default` 两条变体 pipeline；后者已在本机用 `openclaw_builder` 跑通 triage / implement / review live smoke
 - Hermes 已作为本机 `supervisor + recorder` 接入，新增 `mission_control_hermes_supervised` 变体 pipeline，但不承担 `implement`
 - 当前分支上的 Web UI control room 已把 CLI / GitHub / Hermes / OpenClaw 的运行态集中到一个本地面板里
 - `Gemini` 和 `Cursor` 已进入受控 agent 注册表，但还没进入默认 assignment

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -133,6 +133,7 @@
 - Web UI 的 run insights 现在新增 `usage` 聚合层，会从 `summary.json` 里汇总 `openclaw_usage` / `openclaw_last_call_usage`，为后续成本展示打底
 - Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
 - Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
+- Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，便于快速看出最近 token 消耗是上升、下降还是持平
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -37,6 +37,7 @@
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
 - 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
 - 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
+- 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-07
+更新时间：2026-05-08
 
 ## 当前记录入口
 
@@ -34,6 +34,7 @@
 - `--doctor-config` 已有 CLI 回归测试并合并到 main，锁定配置诊断路径不会误进入交互模式
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
+- live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -42,6 +42,8 @@
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
+- 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
+- 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -47,6 +47,7 @@
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
 - 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
+- 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；最新 live smoke `run-20260511T230911Z-6e0886` 复现了这个 blocker，并继续给出 OpenClaw fallback 提示
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-12
+更新时间：2026-05-10
 
 ## 当前记录入口
 
@@ -49,7 +49,6 @@
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
 - 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；最新 live smoke `run-20260511T230911Z-6e0886` 复现了这个 blocker，并继续给出 OpenClaw fallback 提示
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
-- 2026-05-12：在 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`、`OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router` 和 `OPENCLAW_AGENT_ID=openclaw-control-ext` 下，`mission_control_default` 的 live smoke `run-20260512T102057Z-4098c0` 已完整跑通 `triage -> implement -> review -> commit_changes -> publish_branch -> sync_issue -> update_issue -> draft_pr -> dispatch_review -> collect_review`，`openclaw-review.yml` workflow `25728503893` 也成功完成，说明默认主链在 OpenClaw override 下已可端到端收敛
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,6 +38,7 @@
 - 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
 - 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
+- 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -45,6 +45,7 @@
 - 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
+- 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-10
+更新时间：2026-05-12
 
 ## 当前记录入口
 
@@ -49,6 +49,7 @@
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
 - 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；最新 live smoke `run-20260511T230911Z-6e0886` 复现了这个 blocker，并继续给出 OpenClaw fallback 提示
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
+- 2026-05-12：在 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`、`OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router` 和 `OPENCLAW_AGENT_ID=openclaw-control-ext` 下，`mission_control_default` 的 live smoke `run-20260512T102057Z-4098c0` 已完整跑通 `triage -> implement -> review -> commit_changes -> publish_branch -> sync_issue -> update_issue -> draft_pr -> dispatch_review -> collect_review`，`openclaw-review.yml` workflow `25728503893` 也成功完成，说明默认主链在 OpenClaw override 下已可端到端收敛
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -130,6 +130,9 @@
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`
 - Web UI 的 history compare 现在也会显示 `latestFailureChanged` 和左右 run 的 `latestFailures`，方便直接判断 GitHub 失败根因是否已经变化
+- Web UI 的 run insights 现在新增 `usage` 聚合层，会从 `summary.json` 里汇总 `openclaw_usage` / `openclaw_last_call_usage`，为后续成本展示打底
+- Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
+- Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-10
+更新时间：2026-05-12
 
 ## 当前记录入口
 
@@ -150,6 +150,7 @@
 - Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
 - Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，便于快速看出最近 token 消耗是上升、下降还是持平
 - Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，桥接输出和可视面板的语义已经对齐
+- Web UI 现在新增 Token Stats 面板，会直接读取当前加载 run 或最近一次 recent run 的 `openclaw_usage` / `openclaw_last_call_usage`，用 token 汇总和 breakdown 辅助看运行态，不再只靠输出区里的单行 usage 文案
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,7 +41,7 @@
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功跑完，workflow run `25642896608` 已验证当前分支的 GitHub review smoke 仍然可用
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -60,6 +60,8 @@
 - 新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可直接回流已有 workflow run 而不重新触发 `dispatch_review`
 - `collect_review` resume 现在会保留外部注入的 workflow run ref，并在 prompt / GitHub workflow_view 命令里一致使用
 - 已用真实 live run `25504962543` 验证 `github_collect_review_resume` 可以直接收敛为 success
+- 2026-05-07：重新跑通 `github_collect_review_resume` live smoke，workflow run `25504962543` 仍能直接收敛为 success
+- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过，当前基线可继续作为收口底座
 - `collect_review` 已支持 failed jobs 摘要回流
 - Web UI 的 run summary / issue update / PR note 现在也会回流 review workflow 的 conclusion 和 failed jobs，方便直接把异步检查结果转成可读结论
 - `collect_review` 在 workflow failed / action_required / in_progress 等状态下，现在也会统一带出 `github_failure_kind`、`github_retryable` 和 `github_recovery_hint`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -67,6 +67,7 @@
 - 非 workflow 的 GitHub 失败现在也会汇总成 `github.latestFailure`，供 Web UI 和导出文案统一消费
 - Web UI 的 Bridge state 现在会优先显示最新 GitHub 失败，而不是把 `draft_pr` / `dispatch_review` 之类的真实失败误表述成“pending”
 - 新增 `github_bridge_smoke` pipeline，可绕过本地 `triage/implement/review` 单独验证 GitHub review workflow
+- Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带入 task payload 和 readiness gate，减少手动改请求体的需要
 - `collect_review` 已支持约 30 秒的短轮询等待，减少 workflow 刚触发时立即返回 `queued` 的手工重跑
 - 2026-05-07 已用真实 `github_bridge_smoke` live run 验证更长 polling 窗口：workflow `25504962543` 在同一次 run 内成功从 dispatch 收敛到 collect success
 - 本地 CLI executor 已有超时护栏，`claude/codex` 长时间无响应时不会再无限挂住 run

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -40,6 +40,7 @@
 - 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
+- 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ python3 main_v2.py --live --request "修复登录页报错" --steps triage,imple
 运行中会输出 `[progress] preflight:start`、`[progress] step:start ...` 这类进度行，避免长步骤看起来像卡住。
 当前还启用了 `runtime.cli_command_timeout_seconds=180.0`，本地 `claude/codex` 长时间无响应时会明确超时失败，而不是无限挂住。
 CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如果默认 `triage` 卡在 Claude，可以优先试 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated`，或者直接切到 `mission_control_openclaw_triage` / `mission_control_openclaw_default`。
+现在如果默认 `triage` 在 Claude 预检阶段超时，preflight 会直接把 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 这条已验证的 OpenClaw fallback 路径提示出来，方便你直接切换。
 `codex_local` 现在默认用 `codex exec --ephemeral`，尽量避开本机 `~/.codex/state_*.sqlite` 迁移冲突；如果仍然返回 `cli_failure_kind=usage_limit`，说明是 Codex 账号配额问题，不是项目编排问题。
 如果 Codex 当前不可用，但你本机 OpenClaw agent 可写仓库，可以显式覆盖实现层：`OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。这样 `mission_control_openclaw_default` 会让 OpenClaw 承担 `implement`，而不是继续卡在 Codex。
 这条 `openclaw_builder` 路径目前主要用于本地 `triage/implement/review`；如果实现结果没有导出可推送分支，`publish_branch` 现在会直接 `blocked`，而不是假装还能继续 GitHub 尾链。

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ OpenClaw 是一个多 AI agent 的 Mission Control。
 
 当前实现和目标方向需要分开看：
 
+项目跟踪入口：
+
+- `PROJECT_STATUS.md`：当前完成度、稳定基线、阻塞项
+- `PROJECT_MEMORY.md`：当前主线、目标文件、下一步
+- `PROJECT_LOG.md`：完整项目日志与历史归档
 - 目标方向：让 OpenClaw 最终成为多 agent 的统一控制面
 - 当前落地：真正的控制层仍然是 `main_v2.py` + `openclaw_v2/`
 - 当前 OpenClaw 现状：已经接入执行层和受控 agent 体系，但还不是默认统一总控入口
@@ -63,6 +68,8 @@ config.yaml               v1 配置
 config_v2.yaml            v2 配置
 FRAMEWORK_V2.md           v2 架构说明
 PROJECT_STATUS.md         当前阶段状态
+PROJECT_MEMORY.md         当前焦点与下一步工作记忆
+PROJECT_LOG.md            完整项目日志归档
 SETUP_GUIDE.md            环境搭建与运行指南
 Solutions.md              方案分析与长期路线
 openclaw_v2/

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ tests/
 - 用来单独验证 GitHub review workflow 的触发和状态回流
 - 适合在本地 `claude/codex` 环境不稳定时排除干扰
 - 它不会经过 `commit_changes` 和 `publish_branch` 步骤
+- 如果这条 smoke 的请求本身不产生文件变更，`commit_changes` / `publish_branch` 会按规则跳过，这属于预期的 no-op 结果
 
 另有一条 GitHub review 回流恢复 pipeline：`github_collect_review_resume`
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ tests/
 - 适合在本地 `claude/codex` 环境不稳定时排除干扰
 - 它不会经过 `commit_changes` 和 `publish_branch` 步骤
 
+另有一条 GitHub review 回流恢复 pipeline：`github_collect_review_resume`
+
+- 只跑 `collect_review`
+- 用来继续收集一个已经存在的 GitHub Actions workflow run 的状态
+- 需要配合 `--workflow-run-ref`，可以传 run id 或 run URL
+- 适合在 workflow 已经触发、但你想稍后回来继续收集结果时使用
+
 ## 快速开始
 
 ### v2 Mission Control
@@ -214,6 +221,15 @@ python3 main_v2.py --pipeline mission_control_hermes_supervised \
 
 ```bash
 python3 main_v2.py --pipeline github_bridge_smoke --request "smoke test github bridge" --steps collect_review
+```
+
+如果你已经有一个现成的 GitHub Actions workflow run，要直接回流状态而不是新触发一次：
+
+```bash
+python3 main_v2.py --pipeline github_collect_review_resume \
+  --request "resume collect review" \
+  --steps collect_review \
+  --workflow-run-ref 25504962543
 ```
 
 5. live 执行

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tests/
 另有两条 OpenClaw 变体 pipeline：
 
 - `mission_control_openclaw_triage`：只把 `triage` 切到本机 `openclaw agent --local --json`
-- `mission_control_openclaw_default`：把 `triage + review` 都切到 OpenClaw，本地 `implement` 和后续 GitHub 步骤保持不变（适用于 Claude 不可用时）
+- `mission_control_openclaw_default`：把 `triage + review` 都切到 OpenClaw；如果 Codex 当前不可用，可以把 `implement` 显式覆盖到 `openclaw_builder`，后续 GitHub 步骤保持不变（适用于 Claude/Codex 不可用时）
 - 当前这样设计是为了先替换最容易受 Claude 环境影响的监督层，不把 gateway / ACP 问题一次性扩大
 - OpenClaw executor 会显式把 repo 绝对路径传给 agent，并要求它先读取 repo 内的 `AGENTS.md`
 

--- a/README.md
+++ b/README.md
@@ -249,6 +249,7 @@ CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如
 `codex_local` 现在默认用 `codex exec --ephemeral`，尽量避开本机 `~/.codex/state_*.sqlite` 迁移冲突；如果仍然返回 `cli_failure_kind=usage_limit`，说明是 Codex 账号配额问题，不是项目编排问题。
 如果 Codex 当前不可用，但你本机 OpenClaw agent 可写仓库，可以显式覆盖实现层：`OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。这样 `mission_control_openclaw_default` 会让 OpenClaw 承担 `implement`，而不是继续卡在 Codex。
 这条 `openclaw_builder` 路径目前主要用于本地 `triage/implement/review`；如果实现结果没有导出可推送分支，`publish_branch` 现在会直接 `blocked`，而不是假装还能继续 GitHub 尾链。
+在 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`、`OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router` 和 `OPENCLAW_AGENT_ID=openclaw-control-ext` 下，`mission_control_default --live` 已在 `run-20260512T102057Z-4098c0` 跑通 `triage -> implement -> review -> commit_changes -> publish_branch -> sync_issue -> update_issue -> draft_pr -> dispatch_review -> collect_review`，并由 `openclaw-review.yml` workflow `25728503893` 收敛为 success；这说明默认主链在 OpenClaw override 下也能端到端收敛。
 当前主线已经补了显式的 `commit_changes` 步骤：只有实现工作区中的改动被提交为干净 commit 后，`publish_branch` 才会继续；如果提交后工作区仍不干净，链路会继续明确 `blocked`。
 如果 live 计划里包含隔离 CLI worktree，而仓库还有未提交改动，preflight 现在会直接拦下；这些 worktree 只基于已提交 `HEAD`，不会自动带上本地脏改动。
 如果当前本地基线分支已经领先上游（例如 `main` ahead of `origin/main`），而计划又要继续 `publish_branch` 或 GitHub 尾链，preflight 现在会在 live 前直接拦下；否则新建的实现分支会把这些未发布的本地提交一起带进 PR。

--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如
 `codex_local` 现在默认用 `codex exec --ephemeral`，尽量避开本机 `~/.codex/state_*.sqlite` 迁移冲突；如果仍然返回 `cli_failure_kind=usage_limit`，说明是 Codex 账号配额问题，不是项目编排问题。
 如果 Codex 当前不可用，但你本机 OpenClaw agent 可写仓库，可以显式覆盖实现层：`OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。这样 `mission_control_openclaw_default` 会让 OpenClaw 承担 `implement`，而不是继续卡在 Codex。
 这条 `openclaw_builder` 路径目前主要用于本地 `triage/implement/review`；如果实现结果没有导出可推送分支，`publish_branch` 现在会直接 `blocked`，而不是假装还能继续 GitHub 尾链。
-在 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`、`OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router` 和 `OPENCLAW_AGENT_ID=openclaw-control-ext` 下，`mission_control_default --live` 已在 `run-20260512T102057Z-4098c0` 跑通 `triage -> implement -> review -> commit_changes -> publish_branch -> sync_issue -> update_issue -> draft_pr -> dispatch_review -> collect_review`，并由 `openclaw-review.yml` workflow `25728503893` 收敛为 success；这说明默认主链在 OpenClaw override 下也能端到端收敛。
 当前主线已经补了显式的 `commit_changes` 步骤：只有实现工作区中的改动被提交为干净 commit 后，`publish_branch` 才会继续；如果提交后工作区仍不干净，链路会继续明确 `blocked`。
 如果 live 计划里包含隔离 CLI worktree，而仓库还有未提交改动，preflight 现在会直接拦下；这些 worktree 只基于已提交 `HEAD`，不会自动带上本地脏改动。
 如果当前本地基线分支已经领先上游（例如 `main` ahead of `origin/main`），而计划又要继续 `publish_branch` 或 GitHub 尾链，preflight 现在会在 live 前直接拦下；否则新建的实现分支会把这些未发布的本地提交一起带进 PR。

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ tests/
 - 适合在本地 `claude/codex` 环境不稳定时排除干扰
 - 它不会经过 `commit_changes` 和 `publish_branch` 步骤
 - 如果这条 smoke 的请求本身不产生文件变更，`commit_changes` / `publish_branch` 会按规则跳过，这属于预期的 no-op 结果
+- 最新 fallback live smoke `run-20260511T224925Z-0203e7` 仍然是 no-op：`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 跳过，而 `triage` / `review` / `sync_issue` / `update_issue` 成功
 
 另有一条 GitHub review 回流恢复 pipeline：`github_collect_review_resume`
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ python3 main_v2.py --live --request "修复登录页报错" --steps triage,imple
 如果某一步只能靠 fallback 才能继续，live 会直接中止，并要求你显式检查 assignment 配置。
 运行中会输出 `[progress] preflight:start`、`[progress] step:start ...` 这类进度行，避免长步骤看起来像卡住。
 当前还启用了 `runtime.cli_command_timeout_seconds=180.0`，本地 `claude/codex` 长时间无响应时会明确超时失败，而不是无限挂住。
-CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如果默认 `triage` 卡在 Claude，可以优先试 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated`，或者直接切到 `mission_control_openclaw_triage` / `mission_control_openclaw_default`。
+CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如果默认 `triage` 卡在 Claude，可以优先试 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated`；如果隔离 Claude 仍显示未登录，就别继续重试，直接切到 `mission_control_openclaw_triage` / `mission_control_openclaw_default`，或配合 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 走已验证的 OpenClaw fallback。
 现在如果默认 `triage` 在 Claude 预检阶段超时，preflight 会直接把 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 这条已验证的 OpenClaw fallback 路径提示出来，方便你直接切换。
 `codex_local` 现在默认用 `codex exec --ephemeral`，尽量避开本机 `~/.codex/state_*.sqlite` 迁移冲突；如果仍然返回 `cli_failure_kind=usage_limit`，说明是 Codex 账号配额问题，不是项目编排问题。
 如果 Codex 当前不可用，但你本机 OpenClaw agent 可写仓库，可以显式覆盖实现层：`OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。这样 `mission_control_openclaw_default` 会让 OpenClaw 承担 `implement`，而不是继续卡在 Codex。

--- a/config_v2.yaml
+++ b/config_v2.yaml
@@ -1152,3 +1152,24 @@ pipelines:
           {user_request}
 
           如果当前没有实现分支，请直接使用默认基线分支。
+
+  github_collect_review_resume:
+    extends: github_bridge_smoke
+    remove_steps:
+      - dispatch_review
+    steps:
+      - id: collect_review
+        depends_on: []
+        title: Resume GitHub review workflow status collection
+        metadata:
+          requires_external_workflow_run_ref: true
+        prompt_template: |
+          请收集现有 GitHub review workflow run 的最新状态，不要触发新的 dispatch_review。
+
+          用户请求：
+          {user_request}
+
+          目标 workflow run：
+          {primary_workflow_run_ref}
+
+          {dependency_summaries}

--- a/docs/superpowers/plans/2026-05-12-token-stats-panel.md
+++ b/docs/superpowers/plans/2026-05-12-token-stats-panel.md
@@ -1,0 +1,117 @@
+# Token Stats Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a dedicated Token Stats panel to the Mission Control Web UI that makes existing OpenClaw usage data easier to read without introducing cost estimation or backend schema changes.
+
+**Architecture:** Reuse the usage summaries already emitted into bootstrap and recent run insights, and present them in a new dashboard panel alongside the existing Hermes and Run Compare cards. Keep all computation client-side in `openclaw_v2/webui/app.js`; no new server endpoints or config fields are needed.
+
+**Tech Stack:** HTML, vanilla JavaScript, existing Web UI CSS layout, Python unittest-based regression checks.
+
+---
+
+### Task 1: Add the Token Stats panel to the Web UI
+
+**Files:**
+- Modify: `openclaw_v2/webui/index.html`
+- Modify: `openclaw_v2/webui/app.js`
+
+- [ ] **Step 1: Add the new panel container to the dashboard layout**
+
+Insert a new `<section class="panel">` inside the existing `insight-grid`, next to `Hermes Control` and `Run Compare`, with:
+- heading: `Token Stats`
+- a short subtitle that says it summarizes OpenClaw usage from the current or latest run
+- a dedicated container with `id="token-stats-panel"`
+
+- [ ] **Step 2: Bind the new DOM node and compute the panel payload**
+
+In `openclaw_v2/webui/app.js`, add a new `elements.tokenStatsPanel = document.getElementById("token-stats-panel")` entry and a small helper that selects usage data from the best available source:
+- prefer the currently loaded run payload when present
+- otherwise fall back to the newest `bootstrap.recentRuns[0]`
+- keep using existing `formatOpenClawUsageSummary()` and `formatOpenClawUsageTrend()` helpers
+
+- [ ] **Step 3: Render a structured token summary**
+
+Implement `renderTokenStatsPanel(bootstrap)` so the panel shows:
+- a status chip that is `passed` when usage data is present and `warning` when it is missing
+- total tokens
+- number of results with usage
+- last-call sample count
+- last-call token total
+- a short note for the most recent trend when more than one recent run exists
+
+The implementation should stay purely presentational and must not introduce any cost/rate conversion.
+
+- [ ] **Step 4: Wire the panel into the existing render flow**
+
+Call the new render helper from the same bootstrap/render path that already refreshes the other dashboard cards, and refresh it again when a run is loaded so the panel always reflects the current dashboard context.
+
+- [ ] **Step 5: Verify the UI source still parses**
+
+Run:
+
+```bash
+node --check openclaw_v2/webui/app.js
+```
+
+Expected: exit 0.
+
+### Task 2: Add regression coverage for the new panel
+
+**Files:**
+- Modify: `tests/test_webui_static.py`
+
+- [ ] **Step 1: Add a static source regression for the panel**
+
+Add assertions that the source now contains:
+- `id="token-stats-panel"`
+- `function renderTokenStatsPanel(bootstrap)`
+- `elements.tokenStatsPanel`
+- the existing usage helpers, not any new rate/cost logic
+
+Also assert the source does not introduce a cost-estimation string such as `estimatedCost`, `usd`, or `rate`.
+
+- [ ] **Step 2: Verify the static test file catches the new surface**
+
+Run:
+
+```bash
+python3 -m unittest tests.test_webui_static
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run the full Python test suite**
+
+Run:
+
+```bash
+python3 -m unittest discover -s tests
+```
+
+Expected: pass.
+
+### Task 3: Sanity-check the dashboard behavior
+
+**Files:**
+- No code changes expected
+
+- [ ] **Step 1: Confirm the dashboard still renders existing usage surfaces**
+
+Verify the updated UI still exposes usage summaries in the places that already relied on them:
+- recent runs
+- run compare
+- run summary output
+
+- [ ] **Step 2: Confirm no backend data model changes were needed**
+
+Check that `openclaw_v2/web.py` and `openclaw_v2/usage_stats.py` remain unchanged, because the panel is built entirely from the data already returned by bootstrap and run insights.
+
+- [ ] **Step 3: Commit once the UI and tests are green**
+
+Use a single commit that covers the dashboard panel and the regression test update.
+
+```bash
+git add openclaw_v2/webui/index.html openclaw_v2/webui/app.js tests/test_webui_static.py
+git commit -m "feat: add token stats panel to web ui"
+```

--- a/main_v2.py
+++ b/main_v2.py
@@ -23,6 +23,11 @@ def _parse_args() -> argparse.Namespace:
         help="Comma-separated step ids to run. Dependencies are included automatically.",
     )
     parser.add_argument(
+        "--workflow-run-ref",
+        default="",
+        help="Existing GitHub workflow run reference for collect_review resume flows.",
+    )
+    parser.add_argument(
         "--live",
         action="store_true",
         help="Run in live mode. Overrides config.runtime.dry_run=false.",
@@ -418,6 +423,7 @@ async def main() -> None:
         config.runtime.dry_run = False
 
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = args.workflow_run_ref.strip()
     selected_steps = [step.strip() for step in args.steps.split(",") if step.strip()] if args.steps else None
     repo_path = os.path.abspath(args.repo_path)
     is_inspection_mode = any(

--- a/openclaw_v2/orchestrator.py
+++ b/openclaw_v2/orchestrator.py
@@ -24,6 +24,7 @@ class HybridOrchestrator:
         self.artifact_store = ArtifactStore()
         self.worktree_manager = WorktreeManager()
         self.preflight_runner = PreflightRunner(config)
+        self.workflow_run_ref = ""
         self.executors = {
             ExecutionMode.CLI: CLIExecutor(config),
             ExecutionMode.GITHUB: GitHubWorkflowExecutor(config),
@@ -37,7 +38,23 @@ class HybridOrchestrator:
         return f"run-{timestamp}-{uuid.uuid4().hex[:6]}"
 
     def build_plan(self, selected_steps: list[str] | None = None) -> list[WorkItem]:
-        return self.planner.build_plan(selected_steps=selected_steps)
+        plan = self.planner.build_plan(selected_steps=selected_steps)
+        self._apply_workflow_run_ref(plan)
+        return plan
+
+    def _apply_workflow_run_ref(self, plan: list[WorkItem]) -> None:
+        workflow_run_ref = str(self.workflow_run_ref).strip()
+        for work_item in plan:
+            profile = self.config.profiles.get(work_item.profile)
+            if workflow_run_ref and profile and profile.action == "workflow_view":
+                work_item.metadata["primary_workflow_run_ref"] = workflow_run_ref
+            if bool(work_item.metadata.get("requires_external_workflow_run_ref", False)) and not str(
+                work_item.metadata.get("primary_workflow_run_ref", "")
+            ).strip():
+                work_item.planning_blocked_reason = (
+                    f"Step {work_item.title} requires an existing GitHub workflow run reference, "
+                    "but none was provided."
+                )
 
     async def preflight(
         self,
@@ -271,6 +288,17 @@ class HybridOrchestrator:
             )
         return ""
 
+    @staticmethod
+    def _required_external_workflow_run_reason(work_item: WorkItem) -> str:
+        if not bool(work_item.metadata.get("requires_external_workflow_run_ref", False)):
+            return ""
+        if str(work_item.metadata.get("primary_workflow_run_ref", "")).strip():
+            return ""
+        return (
+            f"Step {work_item.title} requires an existing GitHub workflow run reference, "
+            "but none was provided."
+        )
+
     @classmethod
     def _pre_execution_block_reason(
         cls,
@@ -280,7 +308,10 @@ class HybridOrchestrator:
         branch_reason = cls._required_dependency_branch_reason(work_item, completed)
         if branch_reason:
             return branch_reason
-        return cls._required_dependency_commit_reason(work_item, completed)
+        commit_reason = cls._required_dependency_commit_reason(work_item, completed)
+        if commit_reason:
+            return commit_reason
+        return cls._required_external_workflow_run_reason(work_item)
 
     @classmethod
     def _dependency_is_satisfied(
@@ -309,6 +340,10 @@ class HybridOrchestrator:
     ) -> str:
         dependency_summaries = self._dependency_summary(work_item, completed)
         dependency_values = self._collect_dependency_values(work_item, completed)
+        primary_workflow_run_ref = str(
+            work_item.metadata.get("primary_workflow_run_ref", "")
+            or dependency_values.get("primary_workflow_run_ref", "")
+        ).strip()
         values = {
             "run_id": context.run_id,
             "user_request": context.user_request,
@@ -319,7 +354,14 @@ class HybridOrchestrator:
             "dependency_summaries": dependency_summaries,
             **dependency_values,
         }
+        values["primary_workflow_run_ref"] = primary_workflow_run_ref
         return work_item.prompt_template.format(**values).strip()
+
+    @staticmethod
+    def _merge_dependency_values(work_item: WorkItem, dependency_values: dict[str, str]) -> None:
+        for key, value in dependency_values.items():
+            if value or key not in work_item.metadata:
+                work_item.metadata[key] = value
 
     @staticmethod
     def _trace_artifacts(work_item: WorkItem) -> dict[str, object]:
@@ -382,7 +424,7 @@ class HybridOrchestrator:
                 )
                 continue
             try:
-                work_item.metadata.update(self._collect_dependency_values(work_item, completed))
+                self._merge_dependency_values(work_item, self._collect_dependency_values(work_item, completed))
                 await self.worktree_manager.prepare(work_item, context)
                 self.artifact_store.write_workspace_manifest(context, work_item)
                 profile = self.config.profiles[work_item.profile]

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -23,6 +23,7 @@ class PreflightRunner:
         checks.extend(self._check_planning_blocks(plan))
         checks.extend(self._check_managed_assignments(plan))
         checks.extend(await self._check_required_commands(plan))
+        checks.extend(await self._check_claude_profiles(repo_path, plan))
         checks.extend(await self._check_openclaw_profiles(repo_path, plan))
         checks.extend(self._check_hermes_profiles(plan))
         checks.extend(await self._check_hermes_runtime(repo_path, plan))
@@ -362,6 +363,96 @@ class PreflightRunner:
                         details={"workspace": workspace, "repo_path": repo_path},
                     )
                 )
+        return checks
+
+    @staticmethod
+    def _profile_env(profile) -> dict[str, str]:
+        env = os.environ.copy()
+        for key in profile.unset_env:
+            env.pop(key, None)
+        return env
+
+    async def _check_claude_profiles(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
+        profile_map = {
+            item.profile: self.config.profiles[item.profile]
+            for item in plan
+            if item.mode == ExecutionMode.CLI
+            and self.config.profiles[item.profile].command
+            and self.config.profiles[item.profile].command[0] == "claude"
+        }
+        if not profile_map or self.config.runtime.dry_run or shutil.which("claude") is None:
+            return []
+
+        checks: list[PreflightCheck] = []
+        for profile_name, profile in profile_map.items():
+            command = [
+                token.format(
+                    prompt="Reply with exactly READY",
+                    repo_path=repo_path,
+                    run_id="preflight",
+                    artifacts_dir="",
+                    workspace_path=repo_path,
+                    branch_name="",
+                )
+                for token in profile.command
+            ]
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=repo_path,
+                env=self._profile_env(profile),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=20)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.communicate()
+                checks.append(
+                    PreflightCheck(
+                        name=f"claude_cli:{profile_name}",
+                        status=CheckStatus.FAILED,
+                        message=(
+                            f"Claude CLI probe timed out for profile `{profile_name}` while checking print-mode auth."
+                        ),
+                        details={"command": command},
+                    )
+                )
+                continue
+
+            output = stdout.decode("utf-8", errors="replace").strip()
+            error_output = stderr.decode("utf-8", errors="replace").strip()
+            if process.returncode == 0:
+                checks.append(
+                    PreflightCheck(
+                        name=f"claude_cli:{profile_name}",
+                        status=CheckStatus.PASSED,
+                        message=f"Claude profile `{profile_name}` passed a print-mode probe.",
+                        details={"command": command},
+                    )
+                )
+                continue
+
+            message = f"Claude CLI probe failed for profile `{profile_name}`."
+            tail = error_output.splitlines()[-1] if error_output else ""
+            if not tail and output:
+                tail = output.splitlines()[-1]
+            if tail:
+                message = f"{message} {tail}"
+            checks.append(
+                PreflightCheck(
+                    name=f"claude_cli:{profile_name}",
+                    status=CheckStatus.FAILED,
+                    message=message,
+                    details={
+                        "command": command,
+                        "exit_code": process.returncode,
+                        "stdout": output,
+                        "stderr": error_output,
+                    },
+                )
+            )
+
         return checks
 
     def _check_hermes_profiles(self, plan: list[WorkItem]) -> list[PreflightCheck]:

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -372,6 +372,16 @@ class PreflightRunner:
             env.pop(key, None)
         return env
 
+    @staticmethod
+    def _claude_recovery_hint(profile_name: str) -> str:
+        hint = (
+            "Recovery: if Codex is unavailable, switch to `mission_control_openclaw_default` "
+            "and set `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`."
+        )
+        if profile_name == "claude_local":
+            hint += " For triage-only debugging, `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated` can isolate ANTHROPIC_* env."
+        return hint
+
     async def _check_claude_profiles(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
         profile_map = {
             item.profile: self.config.profiles[item.profile]
@@ -403,19 +413,26 @@ class PreflightRunner:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
+            communicate = process.communicate()
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=20)
+                stdout, stderr = await asyncio.wait_for(communicate, timeout=20)
             except asyncio.TimeoutError:
+                communicate.close()
                 process.kill()
                 await process.communicate()
+                recovery_hint = self._claude_recovery_hint(profile_name)
                 checks.append(
                     PreflightCheck(
                         name=f"claude_cli:{profile_name}",
                         status=CheckStatus.FAILED,
                         message=(
-                            f"Claude CLI probe timed out for profile `{profile_name}` while checking print-mode auth."
+                            f"Claude CLI probe timed out for profile `{profile_name}` while checking print-mode auth. "
+                            f"{recovery_hint}"
                         ),
-                        details={"command": command},
+                        details={
+                            "command": command,
+                            "recovery_hint": recovery_hint,
+                        },
                     )
                 )
                 continue
@@ -439,6 +456,8 @@ class PreflightRunner:
                 tail = output.splitlines()[-1]
             if tail:
                 message = f"{message} {tail}"
+            recovery_hint = self._claude_recovery_hint(profile_name)
+            message = f"{message} {recovery_hint}"
             checks.append(
                 PreflightCheck(
                     name=f"claude_cli:{profile_name}",
@@ -449,6 +468,7 @@ class PreflightRunner:
                         "exit_code": process.returncode,
                         "stdout": output,
                         "stderr": error_output,
+                        "recovery_hint": recovery_hint,
                     },
                 )
             )

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -373,13 +373,15 @@ class PreflightRunner:
         return env
 
     @staticmethod
-    def _claude_recovery_hint(profile_name: str) -> str:
+    def _claude_recovery_hint(profile_name: str, stderr_text: str = "") -> str:
         hint = (
             "Recovery: if Codex is unavailable, switch to `mission_control_openclaw_default` "
             "and set `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`."
         )
         if profile_name == "claude_local":
             hint += " For triage-only debugging, `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated` can isolate ANTHROPIC_* env."
+        if profile_name.endswith("_isolated") and ("Not logged in" in stderr_text or "Please run /login" in stderr_text):
+            hint += " The isolated Claude profile is not authenticated here, so the OpenClaw fallback is the practical live path."
         return hint
 
     async def _check_claude_profiles(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
@@ -456,7 +458,7 @@ class PreflightRunner:
                 tail = output.splitlines()[-1]
             if tail:
                 message = f"{message} {tail}"
-            recovery_hint = self._claude_recovery_hint(profile_name)
+            recovery_hint = self._claude_recovery_hint(profile_name, error_output or output)
             message = f"{message} {recovery_hint}"
             checks.append(
                 PreflightCheck(

--- a/openclaw_v2/usage_stats.py
+++ b/openclaw_v2/usage_stats.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+USAGE_FIELDS = ("input", "output", "cacheRead", "cacheWrite", "total")
+
+
+def _empty_usage() -> dict[str, int]:
+    return {field: 0 for field in USAGE_FIELDS}
+
+
+def _usage_payload(value: Any) -> dict[str, int] | None:
+    if not isinstance(value, dict):
+        return None
+
+    payload = _empty_usage()
+    derived_total = 0
+    seen = False
+    saw_total = False
+    for field in USAGE_FIELDS:
+        field_value = value.get(field)
+        if isinstance(field_value, bool) or not isinstance(field_value, int):
+            continue
+        payload[field] += field_value
+        if field != "total":
+            derived_total += field_value
+        else:
+            saw_total = True
+        seen = True
+    if seen and not saw_total:
+        payload["total"] = derived_total
+    return payload if seen else None
+
+
+def _add_usage(total: dict[str, int], usage: dict[str, int]) -> None:
+    for field in USAGE_FIELDS:
+        total[field] += usage[field]
+
+
+def summarize_openclaw_usage(summary: dict[str, Any]) -> dict[str, Any]:
+    results = summary.get("results", [])
+    if not isinstance(results, list):
+        results = []
+
+    result_count = 0
+    usage_count = 0
+    last_call_usage_count = 0
+    usage_totals = _empty_usage()
+    last_call_usage_totals = _empty_usage()
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        result_count += 1
+
+        artifacts = item.get("artifacts", {})
+        if not isinstance(artifacts, dict):
+            continue
+
+        usage = _usage_payload(artifacts.get("openclaw_usage"))
+        if usage is not None:
+            _add_usage(usage_totals, usage)
+            usage_count += 1
+
+        last_call_usage = _usage_payload(artifacts.get("openclaw_last_call_usage"))
+        if last_call_usage is not None:
+            _add_usage(last_call_usage_totals, last_call_usage)
+            last_call_usage_count += 1
+
+    return {
+        "resultCount": result_count,
+        "openclawUsageCount": usage_count,
+        "openclawLastCallUsageCount": last_call_usage_count,
+        "openclawUsage": usage_totals,
+        "openclawLastCallUsage": last_call_usage_totals,
+    }
+
+
+def compare_openclaw_usage(left_usage: dict[str, Any], right_usage: dict[str, Any]) -> dict[str, Any]:
+    left = left_usage if isinstance(left_usage, dict) else {}
+    right = right_usage if isinstance(right_usage, dict) else {}
+    left_totals = left.get("openclawUsage", {})
+    right_totals = right.get("openclawUsage", {})
+    left_last_call_totals = left.get("openclawLastCallUsage", {})
+    right_last_call_totals = right.get("openclawLastCallUsage", {})
+    left_result_count = left.get("resultCount", 0)
+    right_result_count = right.get("resultCount", 0)
+    left_usage_count = left.get("openclawUsageCount", 0)
+    right_usage_count = right.get("openclawUsageCount", 0)
+    left_last_call_count = left.get("openclawLastCallUsageCount", 0)
+    right_last_call_count = right.get("openclawLastCallUsageCount", 0)
+
+    return {
+        "resultCountDelta": _int_value(right_result_count) - _int_value(left_result_count),
+        "openclawUsageCountDelta": _int_value(right_usage_count) - _int_value(left_usage_count),
+        "openclawLastCallUsageCountDelta": _int_value(right_last_call_count) - _int_value(left_last_call_count),
+        "openclawUsageTotalDelta": _usage_total(right_totals) - _usage_total(left_totals),
+        "openclawLastCallUsageTotalDelta": _usage_total(right_last_call_totals) - _usage_total(left_last_call_totals),
+        "left": left,
+        "right": right,
+    }
+
+
+def _int_value(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _usage_total(value: Any) -> int:
+    if not isinstance(value, dict):
+        return 0
+    total = value.get("total")
+    return total if isinstance(total, int) and not isinstance(total, bool) else 0

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -257,6 +257,15 @@ def _selected_steps(payload: dict[str, Any]) -> list[str] | None:
     raise web.HTTPBadRequest(text="steps must be a comma-separated string or a list of step ids.")
 
 
+def _workflow_run_ref(payload: dict[str, Any]) -> str:
+    raw_ref = payload.get("workflowRunRef", payload.get("workflow_run_ref", ""))
+    if raw_ref in ("", None):
+        return ""
+    if not isinstance(raw_ref, str):
+        raise web.HTTPBadRequest(text="workflowRunRef must be a string.")
+    return raw_ref.strip()
+
+
 def _default_openclaw_agent_id(config: Any) -> str:
     env_value = os.getenv("OPENCLAW_AGENT_ID", "").strip()
     if env_value:
@@ -1473,6 +1482,7 @@ def _validate_task_submission(action: str, payload: dict[str, Any], config: Any)
         return
 
     selected_steps = _selected_steps(payload)
+    workflow_run_ref = _workflow_run_ref(payload)
 
     if action == "run":
         user_request = str(payload.get("request", "")).strip()
@@ -1484,6 +1494,7 @@ def _validate_task_submission(action: str, payload: dict[str, Any], config: Any)
         live = False
 
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = workflow_run_ref
     if action == "run" and live:
         _validate_live_policy(
             orchestrator,
@@ -1503,6 +1514,7 @@ async def _execute_dashboard_action(
     payload = task.payload
     repo_path, config_path, config = _resolve_request_payload(app, payload)
     selected_steps = _selected_steps(payload)
+    workflow_run_ref = _workflow_run_ref(payload)
 
     if task.action == "doctor":
         task.add_progress("Running config diagnostics.")
@@ -1514,6 +1526,7 @@ async def _execute_dashboard_action(
         }
 
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = workflow_run_ref
 
     if task.action in {"diagnose", "preflight"}:
         task.add_progress("Running preflight.")
@@ -1538,6 +1551,7 @@ async def _execute_dashboard_action(
     live = _read_json_bool_field(payload, "live", False)
     config.runtime.dry_run = not live
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = workflow_run_ref
     if live:
         _validate_live_policy(
             orchestrator,

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -20,6 +20,7 @@ from .config import AppConfig, diagnose_app_config, load_app_config, resolve_run
 from .github_support import normalize_github_repo, resolve_github_repo_from_origin
 from .models import TaskStatus
 from .orchestrator import HybridOrchestrator
+from .usage_stats import compare_openclaw_usage, summarize_openclaw_usage
 
 APP_CONFIG_PATH = web.AppKey("config_path", str)
 APP_REPO_PATH = web.AppKey("repo_path", str)
@@ -457,6 +458,7 @@ def _summarize_run_insights(
 ) -> dict[str, Any]:
     results = _summary_results(summary)
     plan = _summary_plan(summary)
+    usage_summary = summarize_openclaw_usage(summary)
     plan_titles = {
         str(item.get("id", "")).strip(): str(item.get("title", "")).strip()
         for item in plan
@@ -660,6 +662,7 @@ def _summarize_run_insights(
             "roles": hermes_roles,
             "checks": hermes_checks,
         },
+        "usage": usage_summary,
     }
 
 
@@ -713,6 +716,8 @@ def _compare_run_histories(left: dict[str, Any], right: dict[str, Any]) -> dict[
     right_latest_failure = _json_object_value(right_github.get("latestFailure"))
     left_hermes = _json_object_value(left_insights.get("hermes"))
     right_hermes = _json_object_value(right_insights.get("hermes"))
+    left_usage = _json_object_value(left_insights.get("usage"))
+    right_usage = _json_object_value(right_insights.get("usage"))
     return {
         "countDiffs": count_diffs,
         "stepDiffs": step_diffs,
@@ -726,6 +731,7 @@ def _compare_run_histories(left: dict[str, Any], right: dict[str, Any]) -> dict[
             "left": left_latest_failure,
             "right": right_latest_failure,
         },
+        "usageDelta": compare_openclaw_usage(left_usage, right_usage),
         "hermesSessionDelta": _json_int_value(right_hermes.get("sessionCount", 0))
         - _json_int_value(left_hermes.get("sessionCount", 0)),
     }

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -28,6 +28,7 @@ const elements = {
   githubBridge: document.getElementById("github-bridge"),
   hermesPanel: document.getElementById("hermes-panel"),
   recentRuns: document.getElementById("recent-runs"),
+  tokenStatsPanel: document.getElementById("token-stats-panel"),
   pruneKeepLatest: document.getElementById("prune-keep-latest"),
   pruneRuns: document.getElementById("prune-runs"),
   housekeepingStatus: document.getElementById("housekeeping-status"),
@@ -558,6 +559,94 @@ function currentOpenClawUsage() {
     return null;
   }
   return runPayload.history?.insights?.usage || runPayload.insights?.usage || null;
+}
+
+function formatUsageBreakdown(usage) {
+  if (!usage || typeof usage !== "object") {
+    return "";
+  }
+  return ["input", "output", "cacheRead", "cacheWrite", "total"]
+    .map((field) => `${field} ${Number.isInteger(usage[field]) ? usage[field] : 0}`)
+    .join(" · ");
+}
+
+function tokenStatsSnapshot(bootstrap) {
+  const runPayload = extractRunPayload(state.currentOutput);
+  if (runPayload) {
+    return {
+      label: runPayload.runResult?.run_id || runPayload.summary?.run_id || "loaded run",
+      source: "loaded run",
+      usage: runPayload.history?.insights?.usage || runPayload.insights?.usage || null,
+      recentRuns: Array.isArray(bootstrap?.recentRuns) ? bootstrap.recentRuns : [],
+    };
+  }
+
+  const recentRuns = Array.isArray(bootstrap?.recentRuns) ? bootstrap.recentRuns : [];
+  const latestRun = recentRuns[0] || null;
+  return {
+    label: latestRun?.runId || "latest recent run",
+    source: latestRun ? "latest recent run" : "no recent runs",
+    usage: latestRun?.insights?.usage || null,
+    recentRuns,
+  };
+}
+
+function renderTokenStatsPanel(bootstrap) {
+  const snapshot = tokenStatsSnapshot(bootstrap);
+  const usage = snapshot.usage;
+  const usageSummary = formatOpenClawUsageSummary(usage);
+  const usageTrend = formatOpenClawUsageTrend(snapshot.recentRuns);
+  const usageSummaryMarkup = usageSummary ? `<p>${escapeHtml(usageSummary)}</p>` : "";
+
+  if (!elements.tokenStatsPanel) {
+    return;
+  }
+
+  if (!usage) {
+    elements.tokenStatsPanel.innerHTML = `
+      <div class="empty-state">No OpenClaw usage artifacts were found for ${escapeHtml(snapshot.label)}.</div>
+      ${usageTrend ? `<small>${escapeHtml(`Recent trend: ${usageTrend.text}`)}</small>` : ""}
+    `;
+    return;
+  }
+
+  const aggregateBreakdown = formatUsageBreakdown(usage.openclawUsage || null);
+  const lastCallBreakdown = formatUsageBreakdown(usage.openclawLastCallUsage || null);
+  elements.tokenStatsPanel.innerHTML = `
+    <article class="result-card">
+      <div class="result-card-header">
+        <strong>${escapeHtml(snapshot.label)}</strong>
+        ${makeStatusChip("passed")}
+      </div>
+      ${usageSummaryMarkup}
+      <small>${escapeHtml(`Source: ${snapshot.source}`)}</small>
+      <div class="metric-grid">
+        <div class="metric-card">
+          <dt>Results with usage</dt>
+          <dd>${escapeHtml(String(Number.isInteger(usage.openclawUsageCount) ? usage.openclawUsageCount : 0))}</dd>
+          <small>${escapeHtml(`${Number.isInteger(usage.resultCount) ? usage.resultCount : 0} total results`)}</small>
+        </div>
+        <div class="metric-card">
+          <dt>Total tokens</dt>
+          <dd>${escapeHtml(String(Number.isInteger(usage.openclawUsage?.total) ? usage.openclawUsage.total : 0))}</dd>
+          <small>${escapeHtml("Aggregate OpenClaw usage")}</small>
+        </div>
+        <div class="metric-card">
+          <dt>Last-call samples</dt>
+          <dd>${escapeHtml(String(Number.isInteger(usage.openclawLastCallUsageCount) ? usage.openclawLastCallUsageCount : 0))}</dd>
+          <small>${escapeHtml("Most recent call coverage")}</small>
+        </div>
+        <div class="metric-card">
+          <dt>Last-call tokens</dt>
+          <dd>${escapeHtml(String(Number.isInteger(usage.openclawLastCallUsage?.total) ? usage.openclawLastCallUsage.total : 0))}</dd>
+          <small>${escapeHtml("Most recent call total")}</small>
+        </div>
+      </div>
+      ${aggregateBreakdown ? `<div class="metric-card full"><dt>Aggregate breakdown</dt><dd>${escapeHtml(aggregateBreakdown)}</dd></div>` : ""}
+      ${lastCallBreakdown ? `<div class="metric-card full"><dt>Last-call breakdown</dt><dd>${escapeHtml(lastCallBreakdown)}</dd></div>` : ""}
+      ${usageTrend ? `<small>${escapeHtml(`Recent trend: ${usageTrend.text}`)}</small>` : ""}
+    </article>
+  `;
 }
 
 function actionableResults(results) {
@@ -2039,6 +2128,7 @@ function renderBootstrap(bootstrap) {
   renderPipelineDag();
   renderReadinessGate();
   renderRecentRuns(bootstrap);
+  renderTokenStatsPanel(bootstrap);
   renderCompareSelectors(bootstrap);
   renderGitHubBridge();
   renderHermesPanel();
@@ -2396,6 +2486,7 @@ function renderOutput(payload) {
   renderReadinessGate();
   renderGitHubBridge();
   renderHermesPanel();
+  renderTokenStatsPanel(state.bootstrap || {});
 }
 
 async function fetchJson(url, options = {}) {

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -339,6 +339,7 @@ function preflightSnapshotStatus(checks) {
       status: "neutral",
       summary: "No preflight snapshot loaded yet.",
       detail: "Run Preflight or load a recent run to surface the last report here.",
+      recoveryHint: "",
     };
   }
 
@@ -355,7 +356,25 @@ function preflightSnapshotStatus(checks) {
       ? `${problems.length} preflight checks need attention.`
       : "Latest preflight snapshot is clean.",
     detail: `${normalized.length} checks captured from the latest snapshot.`,
+    recoveryHint: formatPreflightRecoveryHint(normalized),
   };
+}
+
+function formatPreflightRecoveryHint(checks) {
+  if (!Array.isArray(checks)) {
+    return "";
+  }
+  for (const check of checks) {
+    const message = String(check?.message || "").trim();
+    if (!message) {
+      continue;
+    }
+    const recoveryIndex = message.indexOf("Recovery:");
+    if (recoveryIndex >= 0) {
+      return message.slice(recoveryIndex).trim();
+    }
+  }
+  return "";
 }
 
 function currentHistoryPayload() {
@@ -755,6 +774,7 @@ function renderReadinessGate() {
   const planItems = effectivePlanItems();
   const preflightChecks = latestPreflightChecks();
   const preflight = preflightSnapshotStatus(preflightChecks);
+  const preflightRecovery = formatPreflightRecoveryHint(preflightChecks);
   const allowedLiveSteps = Array.isArray(runtime.allowed_live_steps) ? runtime.allowed_live_steps : [];
   const usesOpenClaw = planItems.some((item) => {
     const mode = String(item.mode || "").toLowerCase();
@@ -899,7 +919,7 @@ function renderReadinessGate() {
       name: "Latest preflight",
       status: preflight.status,
       summary: preflight.summary,
-      detail: preflight.detail,
+      detail: preflightRecovery ? `${preflight.detail} ${preflightRecovery}` : preflight.detail,
     },
   ];
 
@@ -1920,6 +1940,7 @@ function renderHealthSnapshot(payload) {
   renderReadinessGate();
   const channels = payload.channels || [];
   const preflight = preflightSnapshotStatus(latestPreflightChecks());
+  const preflightRecovery = formatPreflightRecoveryHint(latestPreflightChecks());
   const preflightSource = latestPreflightSource();
   const gateway = payload.gateway || {};
   const memory = payload.memory || {};
@@ -1969,6 +1990,7 @@ function renderHealthSnapshot(payload) {
         <div class="meta-list">
           <div><dt>Summary</dt><dd>${escapeHtml(preflight.summary)}</dd></div>
           <div><dt>Detail</dt><dd>${escapeHtml(preflight.detail)}</dd></div>
+          ${preflightRecovery ? `<div><dt>Recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>` : ""}
           <div><dt>Source</dt><dd>${escapeHtml(preflightSource)}</dd></div>
         </div>
       </article>

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -499,6 +499,31 @@ function formatOpenClawUsageDelta(usageDelta) {
   return `OpenClaw usage delta: ${parts.join(" · ")}`;
 }
 
+function formatOpenClawUsageTrend(runs) {
+  if (!Array.isArray(runs)) {
+    return null;
+  }
+  const usageRuns = runs
+    .map((run) => {
+      const totalTokens = Number.isInteger(run?.insights?.usage?.openclawUsage?.total)
+        ? run.insights.usage.openclawUsage.total
+        : null;
+      return totalTokens === null ? null : { run, totalTokens };
+    })
+    .filter(Boolean);
+  if (usageRuns.length < 2) {
+    return null;
+  }
+
+  const latest = usageRuns[0];
+  const previous = usageRuns[1];
+  const delta = latest.totalTokens - previous.totalTokens;
+  return {
+    tone: delta > 0 ? "warning" : delta < 0 ? "passed" : "neutral",
+    text: `Latest ${latest.totalTokens} tokens vs previous ${previous.totalTokens} tokens (${delta >= 0 ? "+" : ""}${delta})`,
+  };
+}
+
 function actionableResults(results) {
   return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
 }
@@ -1741,11 +1766,23 @@ function renderRequestPresets() {
 
 function renderRecentRuns(bootstrap) {
   const runs = bootstrap.recentRuns || [];
+  const usageTrend = formatOpenClawUsageTrend(runs);
   if (!runs.length) {
     elements.recentRuns.innerHTML = `<div class="empty-state">No recorded runs yet.</div>`;
     return;
   }
-  elements.recentRuns.innerHTML = runs
+  const trendMarkup = usageTrend
+    ? `
+      <article class="diff-card">
+        <div class="result-card-header">
+          <strong>OpenClaw usage trend</strong>
+          ${makeStatusChip(usageTrend.tone)}
+        </div>
+        <p>${escapeHtml(usageTrend.text)}</p>
+      </article>
+    `
+    : "";
+  elements.recentRuns.innerHTML = `${trendMarkup}${runs
     .map((run) => {
       const latestFailure = run.insights?.github?.latestFailure || null;
       const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);
@@ -1784,7 +1821,7 @@ function renderRecentRuns(bootstrap) {
         </article>
       `;
     })
-    .join("");
+    .join("")}`;
 
   elements.recentRuns.querySelectorAll("button[data-run-id]").forEach((button) => {
     button.addEventListener("click", () => {

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -34,6 +34,7 @@ const elements = {
   healthAgentId: document.getElementById("health-agent-id"),
   checkHealth: document.getElementById("check-health"),
   healthPanel: document.getElementById("health-panel"),
+  workflowRunRef: document.getElementById("workflow-run-ref"),
   taskState: document.getElementById("task-state"),
   cancelTask: document.getElementById("cancel-task"),
   taskMeta: document.getElementById("task-meta"),
@@ -400,6 +401,7 @@ function setCopyFeedback(message) {
 
 function updateActionButtons() {
   const requestReady = Boolean((elements.request.value || "").trim());
+  const workflowRunRefIsReady = workflowRunRefReady();
   const taskActive = ["queued", "running"].includes(state.currentTaskStatus);
   elements.buttons.forEach((button) => {
     if (taskActive) {
@@ -407,7 +409,7 @@ function updateActionButtons() {
       return;
     }
     if (button.dataset.action === "run") {
-      button.disabled = !requestReady;
+      button.disabled = !requestReady || !workflowRunRefIsReady;
       return;
     }
     button.disabled = false;
@@ -644,6 +646,9 @@ function renderReadinessGate() {
   const health = state.healthSnapshot;
   const healthCurrent = healthSnapshotIsCurrent();
   const requestText = (elements.request.value || "").trim();
+  const workflowRunRefValue = currentWorkflowRunRef();
+  const workflowRunRefRequired = pipelineRequiresWorkflowRunRef();
+  const workflowRunRefIsReady = workflowRunRefReady();
   const pipelineSteps = currentPipelineSteps();
   const explicitSelection = selectedSteps();
   const effectiveIds = effectiveStepIds();
@@ -685,6 +690,22 @@ function renderReadinessGate() {
           ? "Live mode requires an explicit subset."
           : `Pipeline: ${elements.pipeline.value || bootstrap.snapshot?.defaultPipeline || "n/a"}`
         : "Refresh bootstrap or check config_v2.yaml.",
+    },
+    {
+      name: "Workflow run ref",
+      status: !workflowRunRefRequired
+        ? "neutral"
+        : workflowRunRefIsReady
+          ? "passed"
+          : "blocked",
+      summary: !workflowRunRefRequired
+        ? "Selected route does not require an existing workflow run reference."
+        : workflowRunRefIsReady
+          ? "Resume workflow reference is ready."
+          : "Provide a GitHub workflow run reference before launching this pipeline.",
+      detail: !workflowRunRefRequired
+        ? "No resume-only step is in the active route."
+        : workflowRunRefValue || "workflowRunRef is missing.",
     },
     {
       name: "Live policy",
@@ -1437,6 +1458,26 @@ function selectedSteps() {
   );
 }
 
+function currentWorkflowRunRef() {
+  return String(elements.workflowRunRef.value || "").trim();
+}
+
+function pipelineRequiresWorkflowRunRef() {
+  const pipelineSteps = currentPipelineSteps();
+  if (!pipelineSteps.length) {
+    return false;
+  }
+  const effectiveIds = new Set(effectiveStepIds());
+  return pipelineSteps.some(
+    (step) =>
+      Boolean(step?.metadata?.requires_external_workflow_run_ref) && effectiveIds.has(step.id),
+  );
+}
+
+function workflowRunRefReady() {
+  return !pipelineRequiresWorkflowRunRef() || Boolean(currentWorkflowRunRef());
+}
+
 function renderWorkspaceMetrics(bootstrap) {
   const git = bootstrap.git || {};
   const snapshot = bootstrap.snapshot || {};
@@ -1560,6 +1601,7 @@ function renderStepGrid() {
       renderPipelineDag();
       renderHeroStatus();
       renderReadinessGate();
+      updateActionButtons();
     });
   });
 }
@@ -2329,6 +2371,7 @@ function taskPayload(action) {
     repoPath: elements.repoPath.value,
     configPath: elements.configPath.value,
     pipeline: elements.pipeline.value,
+    workflowRunRef: currentWorkflowRunRef(),
     request: elements.request.value,
     steps: selectedSteps(),
     live: state.live,
@@ -2431,6 +2474,12 @@ function bindEvents() {
     renderReadinessGate();
   });
 
+  elements.workflowRunRef.addEventListener("input", () => {
+    renderLaunchBrief();
+    renderReadinessGate();
+    updateActionButtons();
+  });
+
   elements.compareLeftRun.addEventListener("change", () => {
     loadRunCompare().catch((error) => {
       elements.runCompare.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
@@ -2501,6 +2550,7 @@ function bindEvents() {
     renderPipelineDag();
     renderHeroStatus();
     renderReadinessGate();
+    updateActionButtons();
   });
 
   elements.selectNone.addEventListener("click", () => {
@@ -2512,6 +2562,7 @@ function bindEvents() {
     renderPipelineDag();
     renderHeroStatus();
     renderReadinessGate();
+    updateActionButtons();
   });
 
   elements.buttons.forEach((button) => {

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -524,6 +524,14 @@ function formatOpenClawUsageTrend(runs) {
   };
 }
 
+function currentOpenClawUsage() {
+  const runPayload = extractRunPayload(state.currentOutput);
+  if (!runPayload) {
+    return null;
+  }
+  return runPayload.history?.insights?.usage || runPayload.insights?.usage || null;
+}
+
 function actionableResults(results) {
   return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
 }
@@ -2210,6 +2218,7 @@ function generateRunSummaryText() {
   const counts = formatCounts(statusCounts(results));
   const actionable = actionableResults(results);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
     `Run ID: ${runResult.run_id || "n/a"}`,
     `Pipeline: ${runPayload.pipeline || "n/a"}`,
@@ -2220,6 +2229,9 @@ function generateRunSummaryText() {
     formatReviewWorkflowLine(workflow),
     `Status counts: ${counts}`,
   ];
+  if (usageLine) {
+    lines.push(usageLine);
+  }
   if (recoveryLine) {
     lines.push(recoveryLine);
   }
@@ -2244,6 +2256,7 @@ function generateIssueUpdateText() {
   const results = runResult.results || [];
   const actionable = actionableResults(results);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
     "OpenClaw progress update",
     "",
@@ -2255,6 +2268,9 @@ function generateIssueUpdateText() {
     `- ${formatReviewWorkflowLine(workflow)}`,
     `- Status counts: ${formatCounts(statusCounts(results))}`,
   ];
+  if (usageLine) {
+    lines.push(`- ${usageLine}`);
+  }
   if (recoveryLine) {
     lines.push(`- ${recoveryLine}`);
   }
@@ -2283,6 +2299,7 @@ function generatePrNoteText() {
     .map((fact) => `${fact.label}:${fact.value}`)
     .join(" · ");
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
     "PR-ready note",
     "",
@@ -2295,6 +2312,9 @@ function generatePrNoteText() {
     formatReviewWorkflowLine(workflow),
     `Status counts: ${formatCounts(statusCounts(runResult.results || []))}`,
   ];
+  if (usageLine) {
+    lines.push(usageLine);
+  }
   if (recoveryLine) {
     lines.push(recoveryLine);
   }

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -377,6 +377,15 @@ function formatPreflightRecoveryHint(checks) {
   return "";
 }
 
+function currentPreflightRecoveryHint() {
+  return formatPreflightRecoveryHint(latestPreflightChecks());
+}
+
+function formatPreflightRecoveryLine(preflightRecovery) {
+  const hint = String(preflightRecovery || "").trim();
+  return hint ? `Preflight recovery: ${hint}` : "";
+}
+
 function currentHistoryPayload() {
   if (state.currentHistory) {
     return state.currentHistory;
@@ -1940,7 +1949,7 @@ function renderHealthSnapshot(payload) {
   renderReadinessGate();
   const channels = payload.channels || [];
   const preflight = preflightSnapshotStatus(latestPreflightChecks());
-  const preflightRecovery = formatPreflightRecoveryHint(latestPreflightChecks());
+  const preflightRecovery = currentPreflightRecoveryHint();
   const preflightSource = latestPreflightSource();
   const gateway = payload.gateway || {};
   const memory = payload.memory || {};
@@ -2133,6 +2142,7 @@ function renderRunResults(runResult, insights = null) {
   const failureLine = formatGitHubFailureLine(failure);
   const failureSummary = formatGitHubFailureSummary(failure);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const preflightRecovery = currentPreflightRecoveryHint();
   const usageLine = formatOpenClawUsageSummary(insights?.usage || null);
   const results = runResult.results || [];
   const visibleResults = filterResults(results);
@@ -2208,6 +2218,7 @@ function renderRunResults(runResult, insights = null) {
           <div><dt>Results</dt><dd>${escapeHtml(String(results.length))}</dd></div>
           <div><dt>Status counts</dt><dd>${escapeHtml(formatCounts(counts))}</dd></div>
           <div><dt>Visible filter</dt><dd>${escapeHtml(state.resultFilter)}</dd></div>
+          ${preflightRecovery ? `<div><dt>Preflight recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>` : ""}
           <div><dt>GitHub latest failure</dt><dd>${escapeHtml(failureLine)}</dd></div>
           ${usageLine ? `<div><dt>OpenClaw usage</dt><dd>${escapeHtml(usageLine)}</dd></div>` : ""}
         </dl>
@@ -2239,6 +2250,7 @@ function generateRunSummaryText() {
   const results = runResult.results || [];
   const counts = formatCounts(statusCounts(results));
   const actionable = actionableResults(results);
+  const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
   const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
@@ -2253,6 +2265,9 @@ function generateRunSummaryText() {
   ];
   if (usageLine) {
     lines.push(usageLine);
+  }
+  if (preflightRecoveryLine) {
+    lines.push(preflightRecoveryLine);
   }
   if (recoveryLine) {
     lines.push(recoveryLine);
@@ -2277,6 +2292,7 @@ function generateIssueUpdateText() {
   const failure = currentGitHubFailure();
   const results = runResult.results || [];
   const actionable = actionableResults(results);
+  const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
   const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
@@ -2292,6 +2308,9 @@ function generateIssueUpdateText() {
   ];
   if (usageLine) {
     lines.push(`- ${usageLine}`);
+  }
+  if (preflightRecoveryLine) {
+    lines.push(`- ${preflightRecoveryLine}`);
   }
   if (recoveryLine) {
     lines.push(`- ${recoveryLine}`);
@@ -2320,6 +2339,7 @@ function generatePrNoteText() {
   const readiness = readinessFacts()
     .map((fact) => `${fact.label}:${fact.value}`)
     .join(" · ");
+  const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
   const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
@@ -2336,6 +2356,9 @@ function generatePrNoteText() {
   ];
   if (usageLine) {
     lines.push(usageLine);
+  }
+  if (preflightRecoveryLine) {
+    lines.push(preflightRecoveryLine);
   }
   if (recoveryLine) {
     lines.push(recoveryLine);

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -432,6 +432,73 @@ function formatCounts(counts) {
   return entries.map(([key, value]) => `${key}:${value}`).join(" · ");
 }
 
+function formatOpenClawUsageSummary(usage) {
+  if (!usage || typeof usage !== "object") {
+    return "";
+  }
+  const resultCount = Number.isInteger(usage.resultCount) ? usage.resultCount : 0;
+  const usageCount = Number.isInteger(usage.openclawUsageCount) ? usage.openclawUsageCount : 0;
+  const lastCallCount = Number.isInteger(usage.openclawLastCallUsageCount)
+    ? usage.openclawLastCallUsageCount
+    : 0;
+  const totalTokens = Number.isInteger(usage.openclawUsage?.total) ? usage.openclawUsage.total : 0;
+  const lastCallTokens = Number.isInteger(usage.openclawLastCallUsage?.total)
+    ? usage.openclawLastCallUsage.total
+    : 0;
+  if (!usageCount && !lastCallCount && !totalTokens && !lastCallTokens) {
+    return "";
+  }
+
+  const parts = [];
+  const resultLabel = resultCount ? `${usageCount}/${resultCount} results with usage` : `${usageCount} results with usage`;
+  parts.push(resultLabel);
+  if (totalTokens) {
+    parts.push(`total ${totalTokens} tokens`);
+  }
+  if (lastCallCount) {
+    parts.push(`${lastCallCount} last-call ${lastCallCount === 1 ? "sample" : "samples"}`);
+  }
+  if (lastCallTokens) {
+    parts.push(`last call ${lastCallTokens} tokens`);
+  }
+  return `OpenClaw usage: ${parts.join(" · ")}`;
+}
+
+function formatOpenClawUsageDelta(usageDelta) {
+  if (!usageDelta || typeof usageDelta !== "object") {
+    return "";
+  }
+  const left = usageDelta.left || {};
+  const right = usageDelta.right || {};
+  const leftResultCount = Number.isInteger(left.resultCount) ? left.resultCount : 0;
+  const rightResultCount = Number.isInteger(right.resultCount) ? right.resultCount : 0;
+  const leftUsageTotal = Number.isInteger(left.openclawUsage?.total) ? left.openclawUsage.total : 0;
+  const rightUsageTotal = Number.isInteger(right.openclawUsage?.total) ? right.openclawUsage.total : 0;
+  const leftLastCallTotal = Number.isInteger(left.openclawLastCallUsage?.total)
+    ? left.openclawLastCallUsage.total
+    : 0;
+  const rightLastCallTotal = Number.isInteger(right.openclawLastCallUsage?.total)
+    ? right.openclawLastCallUsage.total
+    : 0;
+
+  const parts = [];
+  if (leftResultCount || rightResultCount) {
+    parts.push(`results ${leftResultCount}→${rightResultCount} (${rightResultCount - leftResultCount >= 0 ? "+" : ""}${rightResultCount - leftResultCount})`);
+  }
+  if (leftUsageTotal || rightUsageTotal) {
+    const delta = rightUsageTotal - leftUsageTotal;
+    parts.push(`tokens ${leftUsageTotal}→${rightUsageTotal} (${delta >= 0 ? "+" : ""}${delta})`);
+  }
+  if (leftLastCallTotal || rightLastCallTotal) {
+    const delta = rightLastCallTotal - leftLastCallTotal;
+    parts.push(`last-call ${leftLastCallTotal}→${rightLastCallTotal} (${delta >= 0 ? "+" : ""}${delta})`);
+  }
+  if (!parts.length) {
+    return "";
+  }
+  return `OpenClaw usage delta: ${parts.join(" · ")}`;
+}
+
 function actionableResults(results) {
   return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
 }
@@ -1335,12 +1402,14 @@ function renderRunCompare(payload) {
   const runs = payload.runs || [];
   const comparison = payload.comparison || {};
   const latestFailures = comparison.latestFailures || {};
+  const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);
   elements.runCompare.innerHTML = `
     <div class="compare-grid">
       ${runs
         .map(
           (run) => {
             const latestFailure = run.insights?.github?.latestFailure || null;
+            const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);
             const failureRecovery = formatGitHubRecoveryLine(null, latestFailure);
             const failureSummary = formatGitHubFailureSummary(latestFailure);
             return `
@@ -1363,6 +1432,7 @@ function renderRunCompare(payload) {
                 <small>${escapeHtml(formatGitHubFailureLine(run.insights?.github?.latestFailure || null))}</small>
                 ${failureSummary ? `<small>${escapeHtml(failureSummary)}</small>` : ""}
                 ${failureRecovery ? `<small>${escapeHtml(failureRecovery)}</small>` : ""}
+                ${usageLine ? `<small>${escapeHtml(usageLine)}</small>` : ""}
                 <small>${escapeHtml(`Hermes sessions: ${run.insights?.hermes?.sessionCount || 0}`)}</small>
               </article>
             `;
@@ -1384,6 +1454,19 @@ function renderRunCompare(payload) {
         </div>
         <small>${escapeHtml(`Branch changed: ${comparison.branchChanged ? "yes" : "no"} · Workflow changed: ${comparison.workflowChanged ? "yes" : "no"} · Hermes session delta: ${comparison.hermesSessionDelta || 0}`)}</small>
       </article>
+      ${
+        usageDeltaLine
+          ? `
+            <article class="diff-card">
+              <div class="result-card-header">
+                <strong>OpenClaw usage delta</strong>
+                ${makeStatusChip("warning")}
+              </div>
+              <p>${escapeHtml(usageDeltaLine)}</p>
+            </article>
+          `
+          : ""
+      }
       <article class="diff-card">
         <div class="result-card-header">
           <strong>GitHub failure delta</strong>
@@ -1665,6 +1748,7 @@ function renderRecentRuns(bootstrap) {
   elements.recentRuns.innerHTML = runs
     .map((run) => {
       const latestFailure = run.insights?.github?.latestFailure || null;
+      const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);
       const failureRecovery = formatGitHubRecoveryLine(null, latestFailure);
       const failureSummary = formatGitHubFailureSummary(latestFailure);
       const recentRunStatus =
@@ -1691,6 +1775,7 @@ function renderRecentRuns(bootstrap) {
           <small>${escapeHtml(formatGitHubFailureLine(run.insights?.github?.latestFailure || null))}</small>
           ${failureSummary ? `<small>${escapeHtml(failureSummary)}</small>` : ""}
           ${failureRecovery ? `<small>${escapeHtml(`Recovery: ${failureRecovery}`)}</small>` : ""}
+          ${usageLine ? `<small>${escapeHtml(usageLine)}</small>` : ""}
           <small>${escapeHtml(formatAbsoluteTime(run.updatedAt))}</small>
           <div class="task-controls">
             <button class="ghost-button" type="button" data-run-id="${escapeHtml(run.runId)}">Load summary</button>
@@ -1975,12 +2060,13 @@ function renderPlan(plan) {
   `;
 }
 
-function renderRunResults(runResult) {
+function renderRunResults(runResult, insights = null) {
   const workflow = currentGitHubWorkflow();
   const failure = currentGitHubFailure();
   const failureLine = formatGitHubFailureLine(failure);
   const failureSummary = formatGitHubFailureSummary(failure);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(insights?.usage || null);
   const results = runResult.results || [];
   const visibleResults = filterResults(results);
   const counts = statusCounts(results);
@@ -2056,6 +2142,7 @@ function renderRunResults(runResult) {
           <div><dt>Status counts</dt><dd>${escapeHtml(formatCounts(counts))}</dd></div>
           <div><dt>Visible filter</dt><dd>${escapeHtml(state.resultFilter)}</dd></div>
           <div><dt>GitHub latest failure</dt><dd>${escapeHtml(failureLine)}</dd></div>
+          ${usageLine ? `<div><dt>OpenClaw usage</dt><dd>${escapeHtml(usageLine)}</dd></div>` : ""}
         </dl>
         ${failureSummary ? `<small>${escapeHtml(failureSummary)}</small>` : ""}
         ${recoveryLine ? `<small>${escapeHtml(`Recovery: ${recoveryLine}`)}</small>` : ""}
@@ -2191,10 +2278,10 @@ function renderOutput(payload) {
     chunks.push(renderChecks(payload.preflight.checks));
   }
   if (payload.runResult) {
-    chunks.push(renderRunResults(payload.runResult));
+    chunks.push(renderRunResults(payload.runResult, payload.history?.insights || payload.insights || null));
   }
   if (payload.summary) {
-    chunks.push(renderRunResults(payload.summary));
+    chunks.push(renderRunResults(payload.summary, payload.insights || null));
   }
   elements.outputPane.innerHTML = chunks.join("") || `<div class="empty-state">No output captured.</div>`;
   if (payload.history) {

--- a/openclaw_v2/webui/index.html
+++ b/openclaw_v2/webui/index.html
@@ -142,6 +142,20 @@
               <select id="pipeline" name="pipeline"></select>
             </label>
 
+            <label class="field field-full">
+              <span>Workflow run ref</span>
+              <input
+                id="workflow-run-ref"
+                name="workflowRunRef"
+                type="text"
+                autocomplete="off"
+                placeholder="Run id or run URL"
+              />
+              <small class="subtle">
+                Resume an existing GitHub Actions workflow run when the selected pipeline needs one.
+              </small>
+            </label>
+
             <label class="field toggle-field">
               <span>Mode</span>
               <button id="mode-toggle" type="button" class="mode-toggle" aria-pressed="false">

--- a/openclaw_v2/webui/index.html
+++ b/openclaw_v2/webui/index.html
@@ -55,6 +55,16 @@
 
         <section class="panel compact-panel">
           <div class="panel-head">
+            <h2>Token Stats</h2>
+            <span class="subtle">OpenClaw usage from the loaded run or the latest recent run.</span>
+          </div>
+          <div id="token-stats-panel" class="stack">
+            <div class="empty-state">Token usage statistics will appear here after bootstrap loads.</div>
+          </div>
+        </section>
+
+        <section class="panel compact-panel">
+          <div class="panel-head">
             <h2>Housekeeping</h2>
           </div>
           <label class="field">

--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -466,6 +466,47 @@ class MainV2WebModeTests(unittest.IsolatedAsyncioTestCase):
             port=9900,
         )
 
+    async def test_main_passes_workflow_run_ref_to_orchestrator(self) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+                self.workflow_run_ref = ""
+
+            async def run(self, user_input, repo_path, selected_steps=None, progress_callback=None):
+                captured["workflow_run_ref"] = self.workflow_run_ref
+                captured["selected_steps"] = selected_steps
+                return RunResult(
+                    run_id="run-resume",
+                    plan=[],
+                    results=[],
+                    success=True,
+                    artifacts_dir="/tmp/run-resume",
+                )
+
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "main_v2.py",
+                    "--request",
+                    "Resume review collection",
+                    "--steps",
+                    "collect_review",
+                    "--workflow-run-ref",
+                    "25504962543",
+                ],
+            ),
+            mock.patch("main_v2.HybridOrchestrator", FakeOrchestrator),
+            mock.patch("builtins.input", side_effect=AssertionError("request mode should not prompt")),
+        ):
+            await main()
+
+        self.assertEqual(captured["workflow_run_ref"], "25504962543")
+        self.assertEqual(captured["selected_steps"], ["collect_review"])
+
     async def test_main_rejects_web_with_request(self) -> None:
         class FakeOrchestrator:
             def __init__(self, config) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -374,6 +374,69 @@ class OrchestratorExecutionTests(unittest.IsolatedAsyncioTestCase):
         )
         prepare.assert_not_awaited()
 
+    def test_resume_collect_review_plan_requires_an_explicit_workflow_run_ref(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "github_collect_review_resume"
+        orchestrator = HybridOrchestrator(config)
+
+        plan = orchestrator.build_plan()
+
+        self.assertEqual([item.id for item in plan], ["collect_review"])
+        self.assertEqual(plan[0].depends_on, [])
+        self.assertEqual(plan[0].metadata["requires_external_workflow_run_ref"], True)
+        self.assertIn("workflow run reference", plan[0].planning_blocked_reason)
+
+    async def test_resume_collect_review_keeps_injected_workflow_run_ref_through_execution(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "github_collect_review_resume"
+        orchestrator = HybridOrchestrator(config)
+        orchestrator.workflow_run_ref = "25504962543"
+
+        plan = orchestrator.build_plan()
+        self.assertEqual(plan[0].metadata["primary_workflow_run_ref"], "25504962543")
+        self.assertEqual(plan[0].planning_blocked_reason, "")
+
+        context = ExecutionContext(
+            run_id="run-resume",
+            user_request="Resume workflow review collection.",
+            repo_path=os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+            dry_run=False,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+
+        async def prepare(work_item: WorkItem, execution_context: ExecutionContext) -> None:
+            work_item.workspace_path = execution_context.repo_path
+
+        async def execute_github(
+            work_item: WorkItem,
+            profile,
+            execution_context: ExecutionContext,
+            rendered_prompt: str,
+        ) -> AgentResult:
+            self.assertEqual(work_item.metadata["primary_workflow_run_ref"], "25504962543")
+            self.assertIn("25504962543", rendered_prompt)
+            self.assertIn("最新状态", rendered_prompt)
+            return AgentResult(
+                work_item_id=work_item.id,
+                profile=work_item.profile,
+                agent=work_item.agent,
+                mode=work_item.mode,
+                status=TaskStatus.SUCCEEDED,
+                summary="Workflow status collected.",
+            )
+
+        with (
+            mock.patch.object(orchestrator.worktree_manager, "prepare", new=mock.AsyncMock(side_effect=prepare)),
+            mock.patch.object(orchestrator.artifact_store, "write_workspace_manifest"),
+            mock.patch.object(orchestrator.artifact_store, "write_prompt", return_value="/tmp/prompt.txt"),
+            mock.patch.object(orchestrator.artifact_store, "write_result"),
+        ):
+            orchestrator.executors[ExecutionMode.GITHUB].execute = mock.AsyncMock(side_effect=execute_github)
+            results = await orchestrator._execute_ready_items(plan, context, {})
+
+        self.assertEqual(results[0].status, TaskStatus.SUCCEEDED)
+
     async def test_run_emits_progress_messages_for_dry_run_step(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.dry_run = True

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -296,6 +296,21 @@ class PipelineConfigTests(unittest.TestCase):
         self.assertEqual(work_items["collect_review"].managed_agent, "github_review_followup_bridge")
         self.assertEqual(work_items["collect_review"].depends_on, ["dispatch_review"])
 
+    def test_github_collect_review_resume_pipeline_only_contains_collect_review_step(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "github_collect_review_resume"
+        planner = PipelinePlanner(config)
+
+        plan = planner.build_plan()
+        work_items = {item.id: item for item in plan}
+
+        self.assertEqual(list(work_items.keys()), ["collect_review"])
+        self.assertEqual(work_items["collect_review"].mode, ExecutionMode.GITHUB)
+        self.assertEqual(work_items["collect_review"].assignment, "collect_review_bridge")
+        self.assertEqual(work_items["collect_review"].managed_agent, "github_review_followup_bridge")
+        self.assertEqual(work_items["collect_review"].depends_on, [])
+        self.assertTrue(work_items["collect_review"].metadata["requires_external_workflow_run_ref"])
+
     def test_all_named_pipelines_build_without_duplicate_step_ids(self) -> None:
         config = load_app_config("config_v2.yaml")
 
@@ -306,6 +321,7 @@ class PipelineConfigTests(unittest.TestCase):
             "mission_control_openclaw_default",
             "mission_control_hermes_supervised",
             "github_bridge_smoke",
+            "github_collect_review_resume",
         ]:
             config.runtime.pipeline = pipeline_name
             planner = PipelinePlanner(config)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -146,6 +146,57 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[1].status, CheckStatus.PASSED)
         self.assertIn("isolated from the repository root", checks[1].message)
 
+    async def test_claude_cli_probe_passes_when_print_mode_succeeds(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(0, "READY\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertIn("passed a print-mode probe", checks[0].message)
+
+    async def test_claude_cli_probe_reports_auth_failure_early(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local_isolated",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(1, "Not logged in · Please run /login\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("Claude CLI probe failed", checks[0].message)
+        self.assertIn("Not logged in", checks[0].message)
+
     async def test_openclaw_missing_agent_id_lists_available_agents(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.profiles["openclaw_local"].openclaw_agent_id = ""

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import tempfile
@@ -18,6 +19,9 @@ class _FakeProcess:
 
     async def communicate(self):
         return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        return None
 
 
 class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
@@ -196,6 +200,62 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[0].status, CheckStatus.FAILED)
         self.assertIn("Claude CLI probe failed", checks[0].message)
         self.assertIn("Not logged in", checks[0].message)
+
+    async def test_claude_cli_probe_suggests_openclaw_fallback_path(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(1, "", "Not logged in · Please run /login\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("openclaw_builder", checks[0].message)
+        self.assertIn("mission_control_openclaw_default", checks[0].message)
+
+    async def test_claude_cli_probe_timeout_suggests_openclaw_fallback_path(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(0, "")),
+            ):
+                with mock.patch(
+                    "openclaw_v2.preflight.asyncio.wait_for",
+                    side_effect=asyncio.TimeoutError,
+                ):
+                    checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("openclaw_builder", checks[0].message)
+        self.assertIn("mission_control_openclaw_default", checks[0].message)
 
     async def test_openclaw_missing_agent_id_lists_available_agents(self) -> None:
         config = load_app_config("config_v2.yaml")

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -227,6 +227,32 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("openclaw_builder", checks[0].message)
         self.assertIn("mission_control_openclaw_default", checks[0].message)
 
+    async def test_claude_isolated_probe_uses_openclaw_fallback_when_not_logged_in(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local_isolated",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(1, "", "Not logged in · Please run /login\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("claude_local_isolated", checks[0].message)
+        self.assertIn("OpenClaw fallback is the practical live path", checks[0].message)
+
     async def test_claude_cli_probe_timeout_suggests_openclaw_fallback_path(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.dry_run = False

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -1,0 +1,138 @@
+import unittest
+
+from openclaw_v2.usage_stats import compare_openclaw_usage, summarize_openclaw_usage
+
+
+class UsageStatsTests(unittest.TestCase):
+    def test_summarize_openclaw_usage_accumulates_summary_json_results(self) -> None:
+        summary = {
+            "results": [
+                {
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 120,
+                            "output": 40,
+                            "cacheRead": 800,
+                            "cacheWrite": 0,
+                            "total": 160,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 12,
+                            "output": 4,
+                            "cacheRead": 80,
+                            "total": 16,
+                        },
+                    },
+                },
+                {
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 80,
+                            "output": 30,
+                            "cacheRead": 200,
+                            "cacheWrite": 10,
+                            "total": 110,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 8,
+                            "output": 3,
+                            "cacheRead": 20,
+                            "cacheWrite": 1,
+                            "total": 11,
+                        },
+                    },
+                },
+                "ignore-me",
+            ],
+        }
+
+        usage = summarize_openclaw_usage(summary)
+
+        self.assertEqual(usage["resultCount"], 2)
+        self.assertEqual(usage["openclawUsageCount"], 2)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 2)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 200,
+                "output": 70,
+                "cacheRead": 1000,
+                "cacheWrite": 10,
+                "total": 270,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 20,
+                "output": 7,
+                "cacheRead": 100,
+                "cacheWrite": 1,
+                "total": 27,
+            },
+        )
+
+    def test_summarize_openclaw_usage_tolerates_missing_and_malformed_fields(self) -> None:
+        summary = {
+            "results": [
+                {"artifacts": {"openclaw_usage": {"input": "bad", "total": 20}}},
+                {"artifacts": {"openclaw_usage": None, "openclaw_last_call_usage": {"cacheRead": 5}}},
+                {"artifacts": []},
+            ]
+        }
+
+        usage = summarize_openclaw_usage(summary)
+
+        self.assertEqual(usage["resultCount"], 3)
+        self.assertEqual(usage["openclawUsageCount"], 1)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 1)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "total": 20,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 5,
+                "cacheWrite": 0,
+                "total": 5,
+            },
+        )
+
+    def test_compare_openclaw_usage_calculates_deltas(self) -> None:
+        left = {
+            "resultCount": 2,
+            "openclawUsageCount": 1,
+            "openclawLastCallUsageCount": 1,
+            "openclawUsage": {"input": 10, "output": 4, "cacheRead": 8, "cacheWrite": 1, "total": 14},
+            "openclawLastCallUsage": {"input": 3, "output": 1, "cacheRead": 2, "cacheWrite": 0, "total": 4},
+        }
+        right = {
+            "resultCount": 4,
+            "openclawUsageCount": 3,
+            "openclawLastCallUsageCount": 2,
+            "openclawUsage": {"input": 30, "output": 12, "cacheRead": 18, "cacheWrite": 5, "total": 42},
+            "openclawLastCallUsage": {"input": 6, "output": 2, "cacheRead": 4, "cacheWrite": 1, "total": 8},
+        }
+
+        comparison = compare_openclaw_usage(left, right)
+
+        self.assertEqual(comparison["resultCountDelta"], 2)
+        self.assertEqual(comparison["openclawUsageCountDelta"], 2)
+        self.assertEqual(comparison["openclawLastCallUsageCountDelta"], 1)
+        self.assertEqual(comparison["openclawUsageTotalDelta"], 28)
+        self.assertEqual(comparison["openclawLastCallUsageTotalDelta"], 4)
+        self.assertEqual(comparison["left"], left)
+        self.assertEqual(comparison["right"], right)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -118,6 +118,52 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("envPath", payload["integrations"]["hermes"])
         self.assertNotIn("managedAgents", payload["snapshot"])
         self.assertNotIn("assignments", payload["snapshot"])
+
+    async def test_bootstrap_recent_runs_include_openclaw_usage_summary(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-usage")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "run_id": "run-usage",
+                    "plan": [],
+                    "results": [
+                        {
+                            "work_item_id": "triage",
+                            "status": "succeeded",
+                            "artifacts": {
+                                "openclaw_usage": {
+                                    "input": 80,
+                                    "output": 20,
+                                    "cacheRead": 400,
+                                    "total": 100,
+                                },
+                                "openclaw_last_call_usage": {
+                                    "input": 8,
+                                    "output": 2,
+                                    "cacheRead": 40,
+                                    "total": 10,
+                                },
+                            },
+                        }
+                    ],
+                    "success": True,
+                },
+                handle,
+            )
+
+        response = await self.client.get("/api/bootstrap")
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        recent = payload["recentRuns"][0]
+        usage = recent["insights"]["usage"]
+        self.assertEqual(recent["runId"], "run-usage")
+        self.assertEqual(usage["resultCount"], 1)
+        self.assertEqual(usage["openclawUsageCount"], 1)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 1)
+        self.assertEqual(usage["openclawUsage"]["total"], 100)
+        self.assertEqual(usage["openclawLastCallUsage"]["total"], 10)
+
     async def test_index_serves_readiness_and_output_controls(self) -> None:
         response = await self.client.get("/")
         self.assertEqual(response.status, 200)
@@ -804,7 +850,21 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
                             "work_item_id": "publish_branch",
                             "status": "succeeded",
                             "mode": "cli",
-                            "artifacts": {"source_branch": "branch-a"},
+                            "artifacts": {
+                                "source_branch": "branch-a",
+                                "openclaw_usage": {
+                                    "input": 10,
+                                    "output": 4,
+                                    "cacheRead": 100,
+                                    "total": 14,
+                                },
+                                "openclaw_last_call_usage": {
+                                    "input": 3,
+                                    "output": 1,
+                                    "cacheRead": 20,
+                                    "total": 4,
+                                },
+                            },
                         },
                         {
                             "work_item_id": "draft_pr",
@@ -838,7 +898,23 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
                             "work_item_id": "publish_branch",
                             "status": "blocked",
                             "mode": "cli",
-                            "artifacts": {"source_branch": "branch-b"},
+                            "artifacts": {
+                                "source_branch": "branch-b",
+                                "openclaw_usage": {
+                                    "input": 30,
+                                    "output": 12,
+                                    "cacheRead": 300,
+                                    "cacheWrite": 5,
+                                    "total": 47,
+                                },
+                                "openclaw_last_call_usage": {
+                                    "input": 6,
+                                    "output": 2,
+                                    "cacheRead": 40,
+                                    "cacheWrite": 1,
+                                    "total": 9,
+                                },
+                            },
                         },
                         {
                             "work_item_id": "draft_pr",
@@ -872,6 +948,8 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(payload["comparison"]["branchChanged"])
         self.assertTrue(payload["comparison"]["latestFailureChanged"])
         self.assertEqual(payload["comparison"]["hermesSessionDelta"], 1)
+        self.assertEqual(payload["comparison"]["usageDelta"]["openclawUsageTotalDelta"], 33)
+        self.assertEqual(payload["comparison"]["usageDelta"]["openclawLastCallUsageTotalDelta"], 5)
         self.assertTrue(any(item["stepId"] == "publish_branch" for item in payload["comparison"]["stepDiffs"]))
         self.assertEqual(payload["runs"][1]["insights"]["github"]["latestFailure"]["stepId"], "draft_pr")
         self.assertEqual(
@@ -1858,6 +1936,146 @@ class WebHermesInsightTests(unittest.TestCase):
         self.assertEqual(roles["triage"], "supervisor")
         self.assertEqual(insights["hermes"]["sessionCount"], 2)
         self.assertTrue(insights["hermes"]["used"])
+
+
+class WebUsageInsightTests(unittest.TestCase):
+    def test_openclaw_usage_is_aggregated_in_run_insights(self) -> None:
+        summary = {
+            "results": [
+                {
+                    "work_item_id": "triage",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 100,
+                            "output": 40,
+                            "cacheRead": 1000,
+                            "total": 140,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 10,
+                            "output": 4,
+                            "cacheRead": 100,
+                            "cacheWrite": 2,
+                            "total": 14,
+                        },
+                    },
+                },
+                {
+                    "work_item_id": "review",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 200,
+                            "output": 60,
+                            "cacheRead": 2000,
+                            "cacheWrite": 20,
+                            "total": 260,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 20,
+                            "output": 6,
+                            "cacheRead": 200,
+                            "total": 26,
+                        },
+                    },
+                },
+                {
+                    "work_item_id": "implement",
+                    "status": "succeeded",
+                    "artifacts": {},
+                },
+            ],
+            "plan": [],
+        }
+
+        insights = _summarize_run_insights(
+            summary,
+            {},
+            None,
+            default_github_repo="",
+            github_base_branch="main",
+        )
+
+        usage = insights["usage"]
+        self.assertEqual(usage["resultCount"], 3)
+        self.assertEqual(usage["openclawUsageCount"], 2)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 2)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 300,
+                "output": 100,
+                "cacheRead": 3000,
+                "cacheWrite": 20,
+                "total": 400,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 30,
+                "output": 10,
+                "cacheRead": 300,
+                "cacheWrite": 2,
+                "total": 40,
+            },
+        )
+
+    def test_openclaw_usage_ignores_malformed_payloads(self) -> None:
+        summary = {
+            "results": [
+                {
+                    "work_item_id": "triage",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {"input": "100", "output": 10, "total": 20},
+                        "openclaw_last_call_usage": "bad",
+                    },
+                },
+                {
+                    "work_item_id": "review",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {"input": True, "cacheRead": 5, "total": 7},
+                    },
+                },
+            ],
+            "plan": [],
+        }
+
+        insights = _summarize_run_insights(
+            summary,
+            {},
+            None,
+            default_github_repo="",
+            github_base_branch="main",
+        )
+
+        usage = insights["usage"]
+        self.assertEqual(usage["resultCount"], 2)
+        self.assertEqual(usage["openclawUsageCount"], 2)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 0)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 0,
+                "output": 10,
+                "cacheRead": 5,
+                "cacheWrite": 0,
+                "total": 27,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "total": 0,
+            },
+        )
 
 
 class WebGitHubInsightTests(unittest.TestCase):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1450,6 +1450,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
     async def test_run_task_captures_progress_and_result(self) -> None:
         run_artifacts = os.path.join(self.repo_path, ".openclaw", "runs", "run-web-test")
         os.makedirs(run_artifacts, exist_ok=True)
+        captured: dict[str, str] = {}
         with open(os.path.join(run_artifacts, "summary.json"), "w", encoding="utf-8") as handle:
             json.dump(
                 {
@@ -1506,6 +1507,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
                 return []
 
             async def run(self, user_request, repo_path, selected_steps=None, progress_callback=None):
+                captured["workflow_run_ref"] = getattr(self, "workflow_run_ref", "")
                 if progress_callback is not None:
                     progress_callback("preflight:start")
                     progress_callback("step:done implement -> succeeded")
@@ -1521,6 +1523,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
                     "pipeline": "demo_pipeline",
                     "request": "Add a Web UI",
                     "steps": ["implement"],
+                    "workflowRunRef": "25504962543",
                     "live": False,
                 },
             )
@@ -1543,6 +1546,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
             messages = [item["message"] for item in task_payload["progress"]]
             self.assertIn("preflight:start", messages)
             self.assertIn("step:done implement -> succeeded", messages)
+            self.assertEqual(captured["workflow_run_ref"], "25504962543")
             self.assertEqual(task_payload["result"]["mode"], "run")
             self.assertEqual(task_payload["result"]["runResult"]["run_id"], "run-web-test")
             self.assertEqual(task_payload["result"]["history"]["runId"], "run-web-test")

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -159,6 +159,23 @@ class WebUiStaticTests(unittest.TestCase):
         )
         self.assertIn("comparison.usageDelta", source)
 
+    def test_preflight_recovery_hint_is_shared_across_copy_surfaces(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("function currentPreflightRecoveryHint()", source)
+        self.assertIn("function formatPreflightRecoveryLine(preflightRecovery)", source)
+        self.assertIn("const preflightRecovery = currentPreflightRecoveryHint();", source)
+        self.assertIn('<div><dt>Preflight recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>', source)
+        self.assertIn("const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());", source)
+        self.assertEqual(source.count("lines.push(preflightRecoveryLine);"), 2)
+        self.assertEqual(source.count("lines.push(`- ${preflightRecoveryLine}`);"), 1)
+        self.assertEqual(
+            source.count("const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());"),
+            3,
+        )
+
     def test_run_detail_surfaces_latest_github_failure(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -12,6 +12,15 @@ class WebUiStaticTests(unittest.TestCase):
         self.assertIn('return `<span class=\"status-chip ${tone}\">${escapeHtml(normalized)}</span>`;', source)
         self.assertNotIn('class=\"status-chip ${normalized}\"', source)
 
+    def test_launch_pad_exposes_workflow_run_ref_input(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "index.html").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('id="workflow-run-ref"', source)
+        self.assertIn('name="workflowRunRef"', source)
+        self.assertIn("Resume an existing GitHub Actions workflow run", source)
+
     def test_channel_health_status_uses_helper(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"
@@ -24,6 +33,19 @@ class WebUiStaticTests(unittest.TestCase):
             '${makeStatusChip(channels.every((item) => item.probeOk) ? "passed" : "warning")}',
             source,
         )
+
+    def test_task_payload_includes_workflow_run_ref_and_ready_state_checks_it(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("function currentWorkflowRunRef()", source)
+        self.assertIn("function pipelineRequiresWorkflowRunRef()", source)
+        self.assertIn("function workflowRunRefReady()", source)
+        self.assertIn("workflowRunRef: currentWorkflowRunRef(),", source)
+        self.assertIn("const workflowRunRefIsReady = workflowRunRefReady();", source)
+        self.assertIn("elements.workflowRunRef.addEventListener(\"input\"", source)
+        self.assertIn("workflowRunRefReady()", source)
 
     def test_preflight_snapshot_status_is_shared_between_panels(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -131,9 +131,12 @@ class WebUiStaticTests(unittest.TestCase):
 
         self.assertIn("function formatOpenClawUsageSummary(usage)", source)
         self.assertIn("function formatOpenClawUsageDelta(usageDelta)", source)
+        self.assertIn("function formatOpenClawUsageTrend(runs)", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(insights?.usage || null);", source)
         self.assertIn("const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);", source)
+        self.assertIn("const usageTrend = formatOpenClawUsageTrend(runs);", source)
+        self.assertIn("OpenClaw usage trend", source)
         self.assertIn("OpenClaw usage", source)
         self.assertIn("OpenClaw usage delta", source)
         self.assertIn(

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -132,13 +132,20 @@ class WebUiStaticTests(unittest.TestCase):
         self.assertIn("function formatOpenClawUsageSummary(usage)", source)
         self.assertIn("function formatOpenClawUsageDelta(usageDelta)", source)
         self.assertIn("function formatOpenClawUsageTrend(runs)", source)
+        self.assertIn("function currentOpenClawUsage()", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(insights?.usage || null);", source)
         self.assertIn("const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);", source)
         self.assertIn("const usageTrend = formatOpenClawUsageTrend(runs);", source)
+        self.assertIn("const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());", source)
+        self.assertIn("lines.push(usageLine);", source)
+        self.assertIn("lines.push(`- ${usageLine}`);", source)
         self.assertIn("OpenClaw usage trend", source)
         self.assertIn("OpenClaw usage", source)
         self.assertIn("OpenClaw usage delta", source)
+        self.assertIn("generateRunSummaryText()", source)
+        self.assertIn("generateIssueUpdateText()", source)
+        self.assertIn("generatePrNoteText()", source)
         self.assertIn(
             "chunks.push(renderRunResults(payload.runResult, payload.history?.insights || payload.insights || null));",
             source,

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -159,6 +159,28 @@ class WebUiStaticTests(unittest.TestCase):
         )
         self.assertIn("comparison.usageDelta", source)
 
+    def test_token_stats_panel_is_rendered_from_usage_helpers(self) -> None:
+        app_source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+        html_source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "index.html").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('id="token-stats-panel"', html_source)
+        self.assertIn("function formatUsageBreakdown(usage)", app_source)
+        self.assertIn("function tokenStatsSnapshot(bootstrap)", app_source)
+        self.assertIn("function renderTokenStatsPanel(bootstrap)", app_source)
+        self.assertIn("elements.tokenStatsPanel", app_source)
+        self.assertIn("renderTokenStatsPanel(bootstrap);", app_source)
+        self.assertIn("renderTokenStatsPanel(state.bootstrap || {});", app_source)
+        self.assertIn("formatOpenClawUsageSummary(usage)", app_source)
+        self.assertIn("formatOpenClawUsageTrend(snapshot.recentRuns)", app_source)
+        self.assertIn("Aggregate breakdown", app_source)
+        self.assertIn("Last-call breakdown", app_source)
+        self.assertNotIn("estimatedCost", app_source)
+        self.assertNotIn("usd", app_source.lower())
+
     def test_preflight_recovery_hint_is_shared_across_copy_surfaces(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -124,12 +124,34 @@ class WebUiStaticTests(unittest.TestCase):
         self.assertIn("formatGitHubFailureLine(run.insights?.github?.latestFailure || null)", source)
         self.assertIn("Recovery: ${failureRecovery}", source)
 
+    def test_openclaw_usage_is_rendered_from_run_insights(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("function formatOpenClawUsageSummary(usage)", source)
+        self.assertIn("function formatOpenClawUsageDelta(usageDelta)", source)
+        self.assertIn("const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);", source)
+        self.assertIn("const usageLine = formatOpenClawUsageSummary(insights?.usage || null);", source)
+        self.assertIn("const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);", source)
+        self.assertIn("OpenClaw usage", source)
+        self.assertIn("OpenClaw usage delta", source)
+        self.assertIn(
+            "chunks.push(renderRunResults(payload.runResult, payload.history?.insights || payload.insights || null));",
+            source,
+        )
+        self.assertIn(
+            "chunks.push(renderRunResults(payload.summary, payload.insights || null));",
+            source,
+        )
+        self.assertIn("comparison.usageDelta", source)
+
     def test_run_detail_surfaces_latest_github_failure(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("function renderRunResults(runResult)", source)
+        self.assertIn("function renderRunResults(runResult, insights = null)", source)
         self.assertIn("const workflow = currentGitHubWorkflow();", source)
         self.assertIn("const failure = currentGitHubFailure();", source)
         self.assertIn("const failureLine = formatGitHubFailureLine(failure);", source)

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -54,11 +54,14 @@ class WebUiStaticTests(unittest.TestCase):
 
         self.assertIn("function latestPreflightSource()", source)
         self.assertIn("function preflightSnapshotStatus(checks)", source)
+        self.assertIn("function formatPreflightRecoveryHint(checks)", source)
         self.assertIn("const preflight = preflightSnapshotStatus(preflightChecks);", source)
+        self.assertIn("const preflightRecovery = formatPreflightRecoveryHint(preflightChecks);", source)
         self.assertIn("const preflight = preflightSnapshotStatus(latestPreflightChecks());", source)
         self.assertIn("const preflightSource = latestPreflightSource();", source)
         self.assertIn("<div><dt>Source</dt><dd>${escapeHtml(preflightSource)}</dd></div>", source)
         self.assertIn('${makeStatusChip(preflight.status)}', source)
+        self.assertIn('<div><dt>Recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>', source)
         self.assertNotIn(
             'No preflight snapshot loaded yet.',
             source.split("function preflightSnapshotStatus(checks)")[0],


### PR DESCRIPTION
## Summary
- keep the `github_collect_review_resume` pipeline and `--workflow-run-ref` plumbing for re-collecting an existing GitHub review workflow run without retriggering `dispatch_review`
- reorganize project tracking docs into `PROJECT_STATUS.md`, `PROJECT_MEMORY.md`, and `PROJECT_LOG.md`, and surface that split from `README.md`
- surface OpenClaw usage summaries, usage trends, and bridge copy text in the Web UI so the collaboration state is easier to read at a glance
- add a Claude print-mode preflight probe that now points operators at the verified OpenClaw fallback path when headless Claude is unavailable
- propagate preflight recovery hints into the run summary, issue update, and PR note copy text so the fallback path stays visible wherever operators copy text
- clarify the README fallback path for `mission_control_openclaw_default`, including the explicit `openclaw_builder` implement override when Codex is unavailable, and the live guide hint that points at that path when Claude preflight times out
- clarify the `github_bridge_smoke` docs so no-op smoke requests are explicitly understood as skipping `commit_changes` / `publish_branch`, and add the latest no-op fallback live smoke record for `run-20260511T224925Z-0203e7`
- record the latest fallback smoke facts in `PROJECT_STATUS.md` and `PROJECT_MEMORY.md` so the current default-blocked / OpenClaw-working state stays visible in repo docs
- add a Token Stats panel to the Web UI that surfaces current-run or recent-run OpenClaw usage as a token breakdown, without introducing cost estimation or backend schema changes

## Validation
- [x] `python3 -m unittest tests.test_pipeline_config tests.test_main_v2 tests.test_web tests.test_webui_static tests.test_orchestrator`
- [x] `python3 -m unittest tests.test_preflight`
- [x] `python3 -m unittest tests.test_usage_stats`
- [x] `python3 -m unittest discover -s tests`
- [x] `node --check openclaw_v2/webui/app.js`
- [x] live smoke for `mission_control_openclaw_default` with `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` succeeded for `triage / implement / review`
- [x] live smoke for `mission_control_default` now fails fast with a Claude recovery hint that names the OpenClaw fallback path
- [x] live smoke for `github_collect_review_resume` still converges on workflow run `25504962543`
- [x] `openclaw-review.yml` succeeded on head `dc820da` in workflow run `25945272227`
- [x] live smoke for `mission_control_openclaw_default` with `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` and `OPENCLAW_AGENT_ID=openclaw-control-ext` succeeded for `triage / implement / review`
- [x] `git diff --check`
