### PR TITLE
[OpenClaw] Prepare GitHub draft PR summary

### DIFF
--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -56,6 +56,7 @@
 - 2026-05-08：Web UI run insights 新增 `usage` 聚合层，会从 `summary.json` 汇总 `openclaw_usage` / `openclaw_last_call_usage`，后续可以直接接到成本展示而不用改 summary 结构。
 - 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
+- 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -66,7 +66,7 @@
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功完成，workflow run `25642896608` 证明当前分支的 GitHub review smoke 还能正常收敛。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -66,6 +66,7 @@
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功完成，workflow run `25642896608` 证明当前分支的 GitHub review smoke 还能正常收敛。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -59,6 +59,7 @@
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
+- 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。
@@ -68,9 +69,10 @@
 
 1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
 2. 先决定 Claude CLI 可用性 / auth 这条 live 路径的恢复方式：要么把本机 headless Claude 登录补齐，要么在默认 pipeline 里为 triage / review 选择明确的本地 fallback，避免 live smoke 继续依赖隐式外部状态。
-3. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
-4. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
-5. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
+3. 基于 `mission_control_openclaw_default` 已跑通的结果，判断 OpenClaw 变体是否应该继续承担主力 live 基线，还是仅作为对照路径保留。
+4. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
+5. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
+6. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
 
 ## 记录规则
 

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -63,6 +63,7 @@
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
 - 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
+- 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -67,6 +67,8 @@
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
+- 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
+- 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -62,6 +62,7 @@
 - 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
+- 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -57,6 +57,7 @@
 - 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
+- 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -71,6 +71,7 @@
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
 - 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
+- 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -69,6 +69,7 @@
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
 - 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
+- 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-07
+更新时间：2026-05-08
 
 ## 主目标
 
@@ -53,6 +53,9 @@
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
 - 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。
 - 2026-05-07：真实 `github_bridge_smoke` live run 证明原来的 `collect_review` 轮询窗口太短；默认 polling 已从 12 秒提高到约 30 秒，并用真实 run `run-20260507T151929Z-5962a5` / workflow `25504962543` 验证同次 live run 可直接收敛为 success。
+- 2026-05-08：Web UI run insights 新增 `usage` 聚合层，会从 `summary.json` 汇总 `openclaw_usage` / `openclaw_last_call_usage`，后续可以直接接到成本展示而不用改 summary 结构。
+- 2026-05-08：Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，token 量已经能直接在控制台里读出来，下一步可以再决定是否做金额换算或趋势图。
+- 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -33,6 +33,7 @@
 - `README.md`
 - `tests/test_github_executor.py`
 - `tests/test_web.py`
+- `openclaw_v2/webui/index.html`
 - `tests/test_webui_static.py`
 
 ## 最近进展
@@ -45,6 +46,7 @@
 - 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
 - 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
 - 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
+- 2026-05-07：Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带进 task payload 和 readiness gate，避免 resume 流程还要手动改请求体。
 - 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
 - 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -46,6 +46,8 @@
 - 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
 - 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
 - 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
+- 2026-05-07：重新跑通 `github_collect_review_resume` live smoke，workflow run `25504962543` 仍然可直接收敛为 success。
+- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过。
 - 2026-05-07：Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带进 task payload 和 readiness gate，避免 resume 流程还要手动改请求体。
 - 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -58,6 +58,7 @@
 - 2026-05-08：Web UI 的 history compare 现在也会显示 OpenClaw usage delta，已经能直接看两次 run 的 token 消耗差异。
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
+- 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。
@@ -66,9 +67,10 @@
 ## 下一步候选
 
 1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
-2. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
-3. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
-4. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
+2. 先决定 Claude CLI 可用性 / auth 这条 live 路径的恢复方式：要么把本机 headless Claude 登录补齐，要么在默认 pipeline 里为 triage / review 选择明确的本地 fallback，避免 live smoke 继续依赖隐式外部状态。
+3. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
+4. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。
+5. 在默认 pipeline 稳定前，不把 Hermes 扩到 `implement`，也不急着把 OpenClaw 提升为默认控制入口。
 
 ## 记录规则
 

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -59,6 +59,7 @@
 - 2026-05-08：Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，token 变化方向已经能在首页一眼看出来。
 - 2026-05-08：Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，面板和桥接导出已经对齐。
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
+- 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
@@ -68,7 +69,7 @@
 ## 下一步候选
 
 1. 继续稳定 `mission_control_default` 主链，优先做更多真实 GitHub run 验证，减少“本地成功但协作链路不可读”的情况。
-2. 先决定 Claude CLI 可用性 / auth 这条 live 路径的恢复方式：要么把本机 headless Claude 登录补齐，要么在默认 pipeline 里为 triage / review 选择明确的本地 fallback，避免 live smoke 继续依赖隐式外部状态。
+2. Claude CLI 不可用时，优先把 live 路径切到已经验证过的 OpenClaw fallback，而不是继续把时间耗在默认 triage 超时上。
 3. 基于 `mission_control_openclaw_default` 已跑通的结果，判断 OpenClaw 变体是否应该继续承担主力 live 基线，还是仅作为对照路径保留。
 4. 继续收 GitHub bridge 的结果诊断和失败恢复，下一步优先考虑把默认主链的 `publish_branch -> draft_pr -> dispatch_review -> collect_review` 也做一次真实端到端验证，而不是只停留在 smoke pipeline。
 5. 继续把 Web UI 作为本地主控台打磨，但避免把它做成独立产品面，而是服务 Mission Control 主线。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-08
+更新时间：2026-05-09
 
 ## 主目标
 
@@ -61,6 +61,7 @@
 - 2026-05-08：Preflight 现在会对 Claude-backed CLI profile 先跑 print-mode 探针；当前机器上的 live smoke 已因此在 triage 前直接暴露 `claude_local` 的认证/可用性问题，而不是等到后续 step 超时。
 - 2026-05-08：Claude 预检失败提示现在会直接带出 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补 triage 侧 `claude_router_isolated` 的隔离建议。
 - 2026-05-08：在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完整跑通 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环。
+- 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -70,6 +70,7 @@
 - 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
+- 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -72,6 +72,7 @@
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。
 - 2026-05-11：最新 fallback tail-chain smoke 继续表明 `mission_control_default` 仍被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍能继续跑。
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已补上这条记录，tail-chain 继续按 no-op 规则跳过，当前最新可用事实仍是 fallback 组合能继续跑。
+- 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；`run-20260511T230911Z-6e0886` 复现了 blocker，当前可继续的 live 入口还是 OpenClaw fallback。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -65,6 +65,7 @@
 - 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
+- 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,6 +1,6 @@
 # OpenClaw Working Memory
 
-更新时间：2026-05-09
+更新时间：2026-05-10
 
 ## 主目标
 
@@ -64,6 +64,7 @@
 - 2026-05-09：当前机器上的 `mission_control_default --live` 仍会在 `claude_local` 认证超时处被挡住；后续 live 入口要继续显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`，不要把默认主链误当成当前机器上的可用入口。
 - 2026-05-09：即使 triage / review 改用 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍不应再在 Claude 路径上继续耗时，实际可继续的入口还是 OpenClaw fallback。
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
+- 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-03：GitHub review workflow 的 conclusion 和 failed jobs 已回流到 Web UI 的 run summary、issue update 和 PR note 文案。
 - 2026-05-03：GitHub review workflow failed jobs 的 run insights / UI helper / 回归测试已补齐，字符串形态的 failed jobs 也能正确显示。
 - 2026-05-03：Web UI 健康面板在 channels 为空时保持 `warning`，不再误报 `passed`。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -22,11 +22,15 @@
 - `config_v2.yaml`
 - `main_v2.py`
 - `openclaw_v2/web.py`
+- `openclaw_v2/config.py`
 - `openclaw_v2/webui/app.js`
 - `openclaw_v2/executors/github.py`
 - `openclaw_v2/executors/openclaw.py`
 - `openclaw_v2/preflight.py`
 - `openclaw_v2/orchestrator.py`
+- `config_v2.yaml`
+- `main_v2.py`
+- `README.md`
 - `tests/test_github_executor.py`
 - `tests/test_web.py`
 - `tests/test_webui_static.py`
@@ -38,6 +42,9 @@
 - 2026-05-07：非 workflow 的 GitHub 失败现在也会汇总为 `github.latestFailure`，不再只靠 workflow 专属视图承载恢复提示。
 - 2026-05-07：Web UI 的 Bridge state 和导出文案现在会优先显示最新 GitHub 失败的恢复路径，避免 `draft_pr` / `update_issue` / `dispatch_review` 失败被“pending”文案掩盖。
 - 2026-05-07：GitHub bridge cards 现在即使拿不到 issue / PR / workflow 引用，也会为失败步骤保留 operator 卡片，并显示 step summary、failure kind 和 recovery hint。
+- 2026-05-07：新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可以直接回流一个已有 workflow run 的状态，不再额外触发 `dispatch_review`。
+- 2026-05-07：`collect_review` resume 的 workflow run ref 现在会贯穿 plan、prompt、GitHub workflow_view 命令和 Web dashboard 任务提交。
+- 2026-05-07：真实 live run `25504962543` 已验证 `github_collect_review_resume` 能直接收敛为 success。
 - 2026-05-07：Web UI 的 run compare 现在会显示左右 run 的最新 GitHub failure，以及 `latestFailureChanged` 差异，方便直接比较两次 run 的失败根因是否变化。
 - 2026-05-07：Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，不用先点进 run detail 或 compare 才能看出最近几次协作失败发生在哪里。
 - 2026-05-07：Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，点开单次 run 后不再需要再切去 bridge 卡或复制文案才能看出当前协作阻塞点。

--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -66,7 +66,7 @@
 - 2026-05-09：Claude CLI 的 isolated 失败提示现在也会直接指向 OpenClaw fallback，避免 triage / review 隔离看起来像还能单独救活默认 live。
 - 2026-05-10：Web UI 的 readiness gate 和 health 面板现在会直接显示 preflight recovery hint，操作员不用再回到 CLI 日志里找 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，复制出去的 operator 文案和页面上的回退提示保持一致。
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功完成，workflow run `25642959803` 证明当前分支的 GitHub review smoke 还能正常收敛。
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功完成，workflow run `25643659466` 证明当前分支的 GitHub review smoke 还能正常收敛；README 也补了 `github_bridge_smoke` 的 no-op tail-chain 说明。
 - 2026-05-11：`mission_control_default --live` 仍会被 `claude_local` 预检超时挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了这个 blocker，并再次把 OpenClaw fallback 路径提示出来。
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新确认可用，triage / implement / review 都成功。
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 证实了 no-op 请求会自然跳过 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review`，但 `sync_issue` / `update_issue` 仍然会完成。

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,7 +41,7 @@
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `400ad43` 上成功跑完，workflow run `25643659466` 已验证当前分支的 GitHub review smoke 仍然可用；README 也补了 `github_bridge_smoke` 的 no-op tail-chain 说明
 - 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -134,6 +134,7 @@
 - Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
 - Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
 - Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，便于快速看出最近 token 消耗是上升、下降还是持平
+- Web UI 的 run summary / issue update / PR note copy 文本现在也会回流 OpenClaw usage 汇总，桥接输出和可视面板的语义已经对齐
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -35,6 +35,7 @@
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
+- 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -57,6 +57,9 @@
 - 受控 agent 池：Claude / Gemini / Codex / Cursor / OpenClaw
 - GitHub issue / PR / workflow run refs 回流
 - `dispatch_review -> collect_review` workflow 状态回流已落地
+- 新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可直接回流已有 workflow run 而不重新触发 `dispatch_review`
+- `collect_review` resume 现在会保留外部注入的 workflow run ref，并在 prompt / GitHub workflow_view 命令里一致使用
+- 已用真实 live run `25504962543` 验证 `github_collect_review_resume` 可以直接收敛为 success
 - `collect_review` 已支持 failed jobs 摘要回流
 - Web UI 的 run summary / issue update / PR note 现在也会回流 review workflow 的 conclusion 和 failed jobs，方便直接把异步检查结果转成可读结论
 - `collect_review` 在 workflow failed / action_required / in_progress 等状态下，现在也会统一带出 `github_failure_kind`、`github_retryable` 和 `github_recovery_hint`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-08
+更新时间：2026-05-09
 
 ## 当前记录入口
 
@@ -36,6 +36,7 @@
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
 - 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
+- 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,6 +41,7 @@
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功跑完，workflow run `25642896608` 已验证当前分支的 GitHub review smoke 仍然可用
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -44,6 +44,7 @@
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
 - 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
+- 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-09
+更新时间：2026-05-10
 
 ## 当前记录入口
 
@@ -39,6 +39,7 @@
 - 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
+- 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -46,6 +46,7 @@
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
 - 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
+- 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -35,6 +35,7 @@
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
+- 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 
@@ -153,7 +154,7 @@
 
 - 任务拆分仍然以配置驱动 pipeline 为主，已经支持 pipeline 继承 / 覆盖 / remove_steps 组合，planner 也已开始按依赖关系排序，但还不是智能动态 planner
 - OpenClaw 接入骨架已落地，但目前只安全接到 `triage` 变体 pipeline
-- OpenClaw 已验证“仓库外 workspace + repo 绝对路径 handoff”可运行，当前已有 `mission_control_openclaw_triage` 和 `mission_control_openclaw_default` 两条变体 pipeline
+- OpenClaw 已验证“仓库外 workspace + repo 绝对路径 handoff”可运行，当前已有 `mission_control_openclaw_triage` 和 `mission_control_openclaw_default` 两条变体 pipeline；后者已在本机用 `openclaw_builder` 跑通 triage / implement / review live smoke
 - Hermes 已作为本机 `supervisor + recorder` 接入，新增 `mission_control_hermes_supervised` 变体 pipeline，但不承担 `implement`
 - 当前分支上的 Web UI control room 已把 CLI / GitHub / Hermes / OpenClaw 的运行态集中到一个本地面板里
 - `Gemini` 和 `Cursor` 已进入受控 agent 注册表，但还没进入默认 assignment

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -133,6 +133,7 @@
 - Web UI 的 run insights 现在新增 `usage` 聚合层，会从 `summary.json` 里汇总 `openclaw_usage` / `openclaw_last_call_usage`，为后续成本展示打底
 - Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
 - Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
+- Web UI 的 recent runs 现在也会显示相邻 run 的 OpenClaw usage trend，便于快速看出最近 token 消耗是上升、下降还是持平
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -37,6 +37,7 @@
 - live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
 - 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
 - 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
+- 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,6 +1,6 @@
 # OpenClaw Project Status
 
-更新时间：2026-05-07
+更新时间：2026-05-08
 
 ## 当前记录入口
 
@@ -34,6 +34,7 @@
 - `--doctor-config` 已有 CLI 回归测试并合并到 main，锁定配置诊断路径不会误进入交互模式
 - CLI 入口现在会把缺失的 `--config` 转成干净的 `SystemExit`，不再直接抛 traceback
 - CLI 的 `_print_preflight()` 现在会把 `preflight.json` 在 exists/open 之间消失、变成不可读、或变成非对象 JSON 的情况安静降级，不再让 run 结束后的预检摘要打印把进程拖成 traceback
+- live 预检现在会对 Claude-backed CLI profile 先做 print-mode 探针，headless Claude 不可用或未认证时会在 triage 前直接失败，不再把时间浪费在后续 step 超时上
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress
 

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -42,6 +42,8 @@
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
 - 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
+- 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
+- 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -47,6 +47,7 @@
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
 - 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
 - 2026-05-11：最新 fallback live smoke `run-20260511T225359Z-f9e37e` 仍然 no-op；`README.md` 的 `github_bridge_smoke` 说明已追加这条记录，`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 继续跳过，`triage` / `review` / `sync_issue` / `update_issue` 成功
+- 2026-05-12：`mission_control_default --live` 仍被 `claude_local` 预检超时挡住；最新 live smoke `run-20260511T230911Z-6e0886` 复现了这个 blocker，并继续给出 OpenClaw fallback 提示
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -38,6 +38,7 @@
 - 这条 Claude 预检失败现在会直接提示 `mission_control_openclaw_default` + `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 的 OpenClaw fallback 路径，并补充 triage 侧的 `claude_router_isolated` 隔离建议
 - 2026-05-09：当前机器上的 `mission_control_default --live` 预检仍会因 `claude_local` 认证超时被挡住；要继续 live 路径，仍需要显式切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
+- 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -45,6 +45,7 @@
 - 2026-05-11：`mission_control_default --live` 仍会在 `claude_local` 预检超时处被挡住；刚跑的 full tail-chain live smoke `run-20260510T234853Z-1e0133` 复现了同样的 blocker，并继续给出 OpenClaw fallback 提示
 - 2026-05-11：`mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 这条 fallback live smoke `run-20260510T235024Z-9e4662` 已重新跑通 triage / implement / review，确认当前机器仍有可用的本地 live 入口
 - 2026-05-11：`mission_control_openclaw_default` 的 fallback tail-chain smoke `run-20260511T000053Z-03cb79` 结果显示请求本身是 no-op，因此 `commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 按规则跳过，但 `triage` / `review` / `sync_issue` / `update_issue` 仍然实跑成功
+- 2026-05-11：最新 fallback tail-chain smoke 仍确认 `mission_control_default` 会被 `claude_local` 预检挡住，而 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder + OPENCLAW_AGENT_ID=openclaw-control-ext` 仍可继续跑
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -130,6 +130,9 @@
 - Web UI 的 history compare 现在会对 malformed `statusCounts` / `workflow` / `sessionCount` 做保守降级，避免比较摘要被坏字段拖垮
 - Web UI 的 history compare 现在也会保守忽略非列表的 `plan/results`，避免摘要里的结构异常拖出 `500`
 - Web UI 的 history compare 现在也会显示 `latestFailureChanged` 和左右 run 的 `latestFailures`，方便直接判断 GitHub 失败根因是否已经变化
+- Web UI 的 run insights 现在新增 `usage` 聚合层，会从 `summary.json` 里汇总 `openclaw_usage` / `openclaw_last_call_usage`，为后续成本展示打底
+- Web UI 的 recent runs 和 run summary 现在也会显示 OpenClaw usage 汇总，便于先按 token 量做粗粒度观察
+- Web UI 的 history compare 现在也会显示 OpenClaw usage delta，便于直接比较两次 run 的 token 消耗变化
 - Web UI 的 recent runs 列表现在也会显示每次 run 的最新 GitHub failure、失败摘要和 recovery 提示，方便直接从首页判断最近几次协作失败点
 - Web UI 的 loaded run detail 和 artifact context 现在也会显示最新 GitHub failure 与 recovery，单次 run 浏览入口和 bridge/operator 视图的失败语义已基本对齐
 - Web UI 的 runtime snapshot / Hermes overview / GitHub overview 现在会把字符串型布尔和坏列表保守降级，避免配置快照误报

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -41,7 +41,7 @@
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
-- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `ac70fa6` 上成功跑完，workflow run `25642896608` 已验证当前分支的 GitHub review smoke 仍然可用
+- 2026-05-11：PR #13 对应的 `openclaw-review.yml` 在 head `88b8afd` 上成功跑完，workflow run `25642959803` 已验证当前分支的 GitHub review smoke 仍然可用
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -60,6 +60,8 @@
 - 新增 `github_collect_review_resume` pipeline 和 `--workflow-run-ref`，可直接回流已有 workflow run 而不重新触发 `dispatch_review`
 - `collect_review` resume 现在会保留外部注入的 workflow run ref，并在 prompt / GitHub workflow_view 命令里一致使用
 - 已用真实 live run `25504962543` 验证 `github_collect_review_resume` 可以直接收敛为 success
+- 2026-05-07：重新跑通 `github_collect_review_resume` live smoke，workflow run `25504962543` 仍能直接收敛为 success
+- 2026-05-07：全量 Python 单测 221 项通过，`node --check openclaw_v2/webui/app.js` 通过，当前基线可继续作为收口底座
 - `collect_review` 已支持 failed jobs 摘要回流
 - Web UI 的 run summary / issue update / PR note 现在也会回流 review workflow 的 conclusion 和 failed jobs，方便直接把异步检查结果转成可读结论
 - `collect_review` 在 workflow failed / action_required / in_progress 等状态下，现在也会统一带出 `github_failure_kind`、`github_retryable` 和 `github_recovery_hint`

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -67,6 +67,7 @@
 - 非 workflow 的 GitHub 失败现在也会汇总成 `github.latestFailure`，供 Web UI 和导出文案统一消费
 - Web UI 的 Bridge state 现在会优先显示最新 GitHub 失败，而不是把 `draft_pr` / `dispatch_review` 之类的真实失败误表述成“pending”
 - 新增 `github_bridge_smoke` pipeline，可绕过本地 `triage/implement/review` 单独验证 GitHub review workflow
+- Web UI 的 Launch Pad 现在暴露 `workflow run ref` 输入，并会在 `github_collect_review_resume` 选中时把它带入 task payload 和 readiness gate，减少手动改请求体的需要
 - `collect_review` 已支持约 30 秒的短轮询等待，减少 workflow 刚触发时立即返回 `queued` 的手工重跑
 - 2026-05-07 已用真实 `github_bridge_smoke` live run 验证更长 polling 窗口：workflow `25504962543` 在同一次 run 内成功从 dispatch 收敛到 collect success
 - 本地 CLI executor 已有超时护栏，`claude/codex` 长时间无响应时不会再无限挂住 run

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -40,6 +40,7 @@
 - 2026-05-09：即使把 triage / review 都切到 `claude_router_isolated`，当前机器上的 `claude_local_isolated` 也未登录；默认 live 仍会在预检阶段被挡住，实际可继续的入口还是 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
 - 2026-05-09：Claude CLI 诊断现在会在 `_isolated` 未登录时直接说明 OpenClaw fallback 才是实际可继续的 live 路径，不再让 triage / review 隔离看起来像还能单独救活默认 live
 - 2026-05-10：Web UI 的 readiness gate 和 health 预检面板现在会直接显示 preflight recovery hint，帮助操作员一眼看出默认 live 该切到 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`
+- 2026-05-10：Web UI 的 run summary / issue update / PR note copy 现在也会回流 preflight recovery hint，和 readiness gate / health 面板一起把默认 live 的回退路径写到可复制文本里
 - 在 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 下，`mission_control_openclaw_default` 已完成 triage / implement / review live smoke，说明 OpenClaw 变体已经具备可用的本地闭环
 - 支持 `--web` 本地 Mission Control 控制台
 - live 运行时会输出 step 级 progress

--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ python3 main_v2.py --live --request "修复登录页报错" --steps triage,imple
 运行中会输出 `[progress] preflight:start`、`[progress] step:start ...` 这类进度行，避免长步骤看起来像卡住。
 当前还启用了 `runtime.cli_command_timeout_seconds=180.0`，本地 `claude/codex` 长时间无响应时会明确超时失败，而不是无限挂住。
 CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如果默认 `triage` 卡在 Claude，可以优先试 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated`，或者直接切到 `mission_control_openclaw_triage` / `mission_control_openclaw_default`。
+现在如果默认 `triage` 在 Claude 预检阶段超时，preflight 会直接把 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 这条已验证的 OpenClaw fallback 路径提示出来，方便你直接切换。
 `codex_local` 现在默认用 `codex exec --ephemeral`，尽量避开本机 `~/.codex/state_*.sqlite` 迁移冲突；如果仍然返回 `cli_failure_kind=usage_limit`，说明是 Codex 账号配额问题，不是项目编排问题。
 如果 Codex 当前不可用，但你本机 OpenClaw agent 可写仓库，可以显式覆盖实现层：`OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。这样 `mission_control_openclaw_default` 会让 OpenClaw 承担 `implement`，而不是继续卡在 Codex。
 这条 `openclaw_builder` 路径目前主要用于本地 `triage/implement/review`；如果实现结果没有导出可推送分支，`publish_branch` 现在会直接 `blocked`，而不是假装还能继续 GitHub 尾链。

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ tests/
 - 用来单独验证 GitHub review workflow 的触发和状态回流
 - 适合在本地 `claude/codex` 环境不稳定时排除干扰
 - 它不会经过 `commit_changes` 和 `publish_branch` 步骤
+- 如果这条 smoke 的请求本身不产生文件变更，`commit_changes` / `publish_branch` 会按规则跳过，这属于预期的 no-op 结果
 
 另有一条 GitHub review 回流恢复 pipeline：`github_collect_review_resume`
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,13 @@ tests/
 - 适合在本地 `claude/codex` 环境不稳定时排除干扰
 - 它不会经过 `commit_changes` 和 `publish_branch` 步骤
 
+另有一条 GitHub review 回流恢复 pipeline：`github_collect_review_resume`
+
+- 只跑 `collect_review`
+- 用来继续收集一个已经存在的 GitHub Actions workflow run 的状态
+- 需要配合 `--workflow-run-ref`，可以传 run id 或 run URL
+- 适合在 workflow 已经触发、但你想稍后回来继续收集结果时使用
+
 ## 快速开始
 
 ### v2 Mission Control
@@ -214,6 +221,15 @@ python3 main_v2.py --pipeline mission_control_hermes_supervised \
 
 ```bash
 python3 main_v2.py --pipeline github_bridge_smoke --request "smoke test github bridge" --steps collect_review
+```
+
+如果你已经有一个现成的 GitHub Actions workflow run，要直接回流状态而不是新触发一次：
+
+```bash
+python3 main_v2.py --pipeline github_collect_review_resume \
+  --request "resume collect review" \
+  --steps collect_review \
+  --workflow-run-ref 25504962543
 ```
 
 5. live 执行

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ tests/
 另有两条 OpenClaw 变体 pipeline：
 
 - `mission_control_openclaw_triage`：只把 `triage` 切到本机 `openclaw agent --local --json`
-- `mission_control_openclaw_default`：把 `triage + review` 都切到 OpenClaw，本地 `implement` 和后续 GitHub 步骤保持不变（适用于 Claude 不可用时）
+- `mission_control_openclaw_default`：把 `triage + review` 都切到 OpenClaw；如果 Codex 当前不可用，可以把 `implement` 显式覆盖到 `openclaw_builder`，后续 GitHub 步骤保持不变（适用于 Claude/Codex 不可用时）
 - 当前这样设计是为了先替换最容易受 Claude 环境影响的监督层，不把 gateway / ACP 问题一次性扩大
 - OpenClaw executor 会显式把 repo 绝对路径传给 agent，并要求它先读取 repo 内的 `AGENTS.md`
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ tests/
 - 适合在本地 `claude/codex` 环境不稳定时排除干扰
 - 它不会经过 `commit_changes` 和 `publish_branch` 步骤
 - 如果这条 smoke 的请求本身不产生文件变更，`commit_changes` / `publish_branch` 会按规则跳过，这属于预期的 no-op 结果
+- 最新 fallback live smoke `run-20260511T224925Z-0203e7` 仍然是 no-op：`commit_changes` / `publish_branch` / `draft_pr` / `dispatch_review` / `collect_review` 跳过，而 `triage` / `review` / `sync_issue` / `update_issue` 成功
 
 另有一条 GitHub review 回流恢复 pipeline：`github_collect_review_resume`
 

--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ python3 main_v2.py --live --request "修复登录页报错" --steps triage,imple
 如果某一步只能靠 fallback 才能继续，live 会直接中止，并要求你显式检查 assignment 配置。
 运行中会输出 `[progress] preflight:start`、`[progress] step:start ...` 这类进度行，避免长步骤看起来像卡住。
 当前还启用了 `runtime.cli_command_timeout_seconds=180.0`，本地 `claude/codex` 长时间无响应时会明确超时失败，而不是无限挂住。
-CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如果默认 `triage` 卡在 Claude，可以优先试 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated`，或者直接切到 `mission_control_openclaw_triage` / `mission_control_openclaw_default`。
+CLI 失败结果现在也会带 `cli_failure_kind` 和 `cli_recovery_hint`。如果默认 `triage` 卡在 Claude，可以优先试 `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated`；如果隔离 Claude 仍显示未登录，就别继续重试，直接切到 `mission_control_openclaw_triage` / `mission_control_openclaw_default`，或配合 `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 走已验证的 OpenClaw fallback。
 现在如果默认 `triage` 在 Claude 预检阶段超时，preflight 会直接把 `mission_control_openclaw_default + OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder` 这条已验证的 OpenClaw fallback 路径提示出来，方便你直接切换。
 `codex_local` 现在默认用 `codex exec --ephemeral`，尽量避开本机 `~/.codex/state_*.sqlite` 迁移冲突；如果仍然返回 `cli_failure_kind=usage_limit`，说明是 Codex 账号配额问题，不是项目编排问题。
 如果 Codex 当前不可用，但你本机 OpenClaw agent 可写仓库，可以显式覆盖实现层：`OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`。这样 `mission_control_openclaw_default` 会让 OpenClaw 承担 `implement`，而不是继续卡在 Codex。

--- a/config_v2.yaml
+++ b/config_v2.yaml
@@ -1152,3 +1152,24 @@ pipelines:
           {user_request}
 
           如果当前没有实现分支，请直接使用默认基线分支。
+
+  github_collect_review_resume:
+    extends: github_bridge_smoke
+    remove_steps:
+      - dispatch_review
+    steps:
+      - id: collect_review
+        depends_on: []
+        title: Resume GitHub review workflow status collection
+        metadata:
+          requires_external_workflow_run_ref: true
+        prompt_template: |
+          请收集现有 GitHub review workflow run 的最新状态，不要触发新的 dispatch_review。
+
+          用户请求：
+          {user_request}
+
+          目标 workflow run：
+          {primary_workflow_run_ref}
+
+          {dependency_summaries}

--- a/docs/superpowers/plans/2026-05-12-readme-mission-control-default-openclaw-fallback-note.md
+++ b/docs/superpowers/plans/2026-05-12-readme-mission-control-default-openclaw-fallback-note.md
@@ -1,0 +1,46 @@
+# README mission_control_default fallback note Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one README line under `mission_control_default` explaining that when Claude CLI is temporarily unavailable, setting `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router` and `OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router` can temporarily move `triage` / `review` to OpenClaw so the default tail chain keeps running.
+
+**Architecture:** This is a documentation-only change in `README.md`. Keep the existing `mission_control_default` description intact and insert a single bullet in the default-pipeline section near the current OpenClaw fallback notes so the guidance is easy to find without changing behavior.
+
+**Tech Stack:** Markdown
+
+---
+
+### Task 1: Locate the insertion point
+
+**Files:**
+- Modify: `README.md:86-103`
+
+- [ ] **Step 1: Review the current `mission_control_default` block**
+  Verify the note belongs in the list immediately after the ten-step pipeline description, before the OpenClaw variant bullets.
+
+- [ ] **Step 2: Confirm the sentence only adds one bullet**
+  Target wording should mention Claude CLI temporarily unavailable, `OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router`, `OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router`, and that this keeps the default tail chain running.
+
+### Task 2: Apply the README edit
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Insert the new bullet**
+  Add one Markdown bullet under the `mission_control_default` explanation with the approved wording; do not change any other bullets or paragraphs.
+
+- [ ] **Step 2: Keep formatting consistent**
+  Match the surrounding Chinese prose, inline code style, and bullet punctuation.
+
+### Task 3: Verify the doc-only diff
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Inspect the diff**
+  Run: `git diff -- README.md`
+  Expected: exactly one added bullet line in the `mission_control_default` section.
+
+- [ ] **Step 2: Sanity-check the rendered text**
+  Run: `sed -n '82,108p' README.md`
+  Expected: the new note appears once, in the intended section, with no unrelated text changes.

--- a/main_v2.py
+++ b/main_v2.py
@@ -23,6 +23,11 @@ def _parse_args() -> argparse.Namespace:
         help="Comma-separated step ids to run. Dependencies are included automatically.",
     )
     parser.add_argument(
+        "--workflow-run-ref",
+        default="",
+        help="Existing GitHub workflow run reference for collect_review resume flows.",
+    )
+    parser.add_argument(
         "--live",
         action="store_true",
         help="Run in live mode. Overrides config.runtime.dry_run=false.",
@@ -418,6 +423,7 @@ async def main() -> None:
         config.runtime.dry_run = False
 
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = args.workflow_run_ref.strip()
     selected_steps = [step.strip() for step in args.steps.split(",") if step.strip()] if args.steps else None
     repo_path = os.path.abspath(args.repo_path)
     is_inspection_mode = any(

--- a/openclaw_v2/orchestrator.py
+++ b/openclaw_v2/orchestrator.py
@@ -24,6 +24,7 @@ class HybridOrchestrator:
         self.artifact_store = ArtifactStore()
         self.worktree_manager = WorktreeManager()
         self.preflight_runner = PreflightRunner(config)
+        self.workflow_run_ref = ""
         self.executors = {
             ExecutionMode.CLI: CLIExecutor(config),
             ExecutionMode.GITHUB: GitHubWorkflowExecutor(config),
@@ -37,7 +38,23 @@ class HybridOrchestrator:
         return f"run-{timestamp}-{uuid.uuid4().hex[:6]}"
 
     def build_plan(self, selected_steps: list[str] | None = None) -> list[WorkItem]:
-        return self.planner.build_plan(selected_steps=selected_steps)
+        plan = self.planner.build_plan(selected_steps=selected_steps)
+        self._apply_workflow_run_ref(plan)
+        return plan
+
+    def _apply_workflow_run_ref(self, plan: list[WorkItem]) -> None:
+        workflow_run_ref = str(self.workflow_run_ref).strip()
+        for work_item in plan:
+            profile = self.config.profiles.get(work_item.profile)
+            if workflow_run_ref and profile and profile.action == "workflow_view":
+                work_item.metadata["primary_workflow_run_ref"] = workflow_run_ref
+            if bool(work_item.metadata.get("requires_external_workflow_run_ref", False)) and not str(
+                work_item.metadata.get("primary_workflow_run_ref", "")
+            ).strip():
+                work_item.planning_blocked_reason = (
+                    f"Step {work_item.title} requires an existing GitHub workflow run reference, "
+                    "but none was provided."
+                )
 
     async def preflight(
         self,
@@ -271,6 +288,17 @@ class HybridOrchestrator:
             )
         return ""
 
+    @staticmethod
+    def _required_external_workflow_run_reason(work_item: WorkItem) -> str:
+        if not bool(work_item.metadata.get("requires_external_workflow_run_ref", False)):
+            return ""
+        if str(work_item.metadata.get("primary_workflow_run_ref", "")).strip():
+            return ""
+        return (
+            f"Step {work_item.title} requires an existing GitHub workflow run reference, "
+            "but none was provided."
+        )
+
     @classmethod
     def _pre_execution_block_reason(
         cls,
@@ -280,7 +308,10 @@ class HybridOrchestrator:
         branch_reason = cls._required_dependency_branch_reason(work_item, completed)
         if branch_reason:
             return branch_reason
-        return cls._required_dependency_commit_reason(work_item, completed)
+        commit_reason = cls._required_dependency_commit_reason(work_item, completed)
+        if commit_reason:
+            return commit_reason
+        return cls._required_external_workflow_run_reason(work_item)
 
     @classmethod
     def _dependency_is_satisfied(
@@ -309,6 +340,10 @@ class HybridOrchestrator:
     ) -> str:
         dependency_summaries = self._dependency_summary(work_item, completed)
         dependency_values = self._collect_dependency_values(work_item, completed)
+        primary_workflow_run_ref = str(
+            work_item.metadata.get("primary_workflow_run_ref", "")
+            or dependency_values.get("primary_workflow_run_ref", "")
+        ).strip()
         values = {
             "run_id": context.run_id,
             "user_request": context.user_request,
@@ -319,7 +354,14 @@ class HybridOrchestrator:
             "dependency_summaries": dependency_summaries,
             **dependency_values,
         }
+        values["primary_workflow_run_ref"] = primary_workflow_run_ref
         return work_item.prompt_template.format(**values).strip()
+
+    @staticmethod
+    def _merge_dependency_values(work_item: WorkItem, dependency_values: dict[str, str]) -> None:
+        for key, value in dependency_values.items():
+            if value or key not in work_item.metadata:
+                work_item.metadata[key] = value
 
     @staticmethod
     def _trace_artifacts(work_item: WorkItem) -> dict[str, object]:
@@ -382,7 +424,7 @@ class HybridOrchestrator:
                 )
                 continue
             try:
-                work_item.metadata.update(self._collect_dependency_values(work_item, completed))
+                self._merge_dependency_values(work_item, self._collect_dependency_values(work_item, completed))
                 await self.worktree_manager.prepare(work_item, context)
                 self.artifact_store.write_workspace_manifest(context, work_item)
                 profile = self.config.profiles[work_item.profile]

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -23,6 +23,7 @@ class PreflightRunner:
         checks.extend(self._check_planning_blocks(plan))
         checks.extend(self._check_managed_assignments(plan))
         checks.extend(await self._check_required_commands(plan))
+        checks.extend(await self._check_claude_profiles(repo_path, plan))
         checks.extend(await self._check_openclaw_profiles(repo_path, plan))
         checks.extend(self._check_hermes_profiles(plan))
         checks.extend(await self._check_hermes_runtime(repo_path, plan))
@@ -362,6 +363,96 @@ class PreflightRunner:
                         details={"workspace": workspace, "repo_path": repo_path},
                     )
                 )
+        return checks
+
+    @staticmethod
+    def _profile_env(profile) -> dict[str, str]:
+        env = os.environ.copy()
+        for key in profile.unset_env:
+            env.pop(key, None)
+        return env
+
+    async def _check_claude_profiles(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
+        profile_map = {
+            item.profile: self.config.profiles[item.profile]
+            for item in plan
+            if item.mode == ExecutionMode.CLI
+            and self.config.profiles[item.profile].command
+            and self.config.profiles[item.profile].command[0] == "claude"
+        }
+        if not profile_map or self.config.runtime.dry_run or shutil.which("claude") is None:
+            return []
+
+        checks: list[PreflightCheck] = []
+        for profile_name, profile in profile_map.items():
+            command = [
+                token.format(
+                    prompt="Reply with exactly READY",
+                    repo_path=repo_path,
+                    run_id="preflight",
+                    artifacts_dir="",
+                    workspace_path=repo_path,
+                    branch_name="",
+                )
+                for token in profile.command
+            ]
+            process = await asyncio.create_subprocess_exec(
+                *command,
+                cwd=repo_path,
+                env=self._profile_env(profile),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            try:
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=20)
+            except asyncio.TimeoutError:
+                process.kill()
+                await process.communicate()
+                checks.append(
+                    PreflightCheck(
+                        name=f"claude_cli:{profile_name}",
+                        status=CheckStatus.FAILED,
+                        message=(
+                            f"Claude CLI probe timed out for profile `{profile_name}` while checking print-mode auth."
+                        ),
+                        details={"command": command},
+                    )
+                )
+                continue
+
+            output = stdout.decode("utf-8", errors="replace").strip()
+            error_output = stderr.decode("utf-8", errors="replace").strip()
+            if process.returncode == 0:
+                checks.append(
+                    PreflightCheck(
+                        name=f"claude_cli:{profile_name}",
+                        status=CheckStatus.PASSED,
+                        message=f"Claude profile `{profile_name}` passed a print-mode probe.",
+                        details={"command": command},
+                    )
+                )
+                continue
+
+            message = f"Claude CLI probe failed for profile `{profile_name}`."
+            tail = error_output.splitlines()[-1] if error_output else ""
+            if not tail and output:
+                tail = output.splitlines()[-1]
+            if tail:
+                message = f"{message} {tail}"
+            checks.append(
+                PreflightCheck(
+                    name=f"claude_cli:{profile_name}",
+                    status=CheckStatus.FAILED,
+                    message=message,
+                    details={
+                        "command": command,
+                        "exit_code": process.returncode,
+                        "stdout": output,
+                        "stderr": error_output,
+                    },
+                )
+            )
+
         return checks
 
     def _check_hermes_profiles(self, plan: list[WorkItem]) -> list[PreflightCheck]:

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -372,6 +372,16 @@ class PreflightRunner:
             env.pop(key, None)
         return env
 
+    @staticmethod
+    def _claude_recovery_hint(profile_name: str) -> str:
+        hint = (
+            "Recovery: if Codex is unavailable, switch to `mission_control_openclaw_default` "
+            "and set `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`."
+        )
+        if profile_name == "claude_local":
+            hint += " For triage-only debugging, `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated` can isolate ANTHROPIC_* env."
+        return hint
+
     async def _check_claude_profiles(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
         profile_map = {
             item.profile: self.config.profiles[item.profile]
@@ -403,19 +413,26 @@ class PreflightRunner:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
             )
+            communicate = process.communicate()
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=20)
+                stdout, stderr = await asyncio.wait_for(communicate, timeout=20)
             except asyncio.TimeoutError:
+                communicate.close()
                 process.kill()
                 await process.communicate()
+                recovery_hint = self._claude_recovery_hint(profile_name)
                 checks.append(
                     PreflightCheck(
                         name=f"claude_cli:{profile_name}",
                         status=CheckStatus.FAILED,
                         message=(
-                            f"Claude CLI probe timed out for profile `{profile_name}` while checking print-mode auth."
+                            f"Claude CLI probe timed out for profile `{profile_name}` while checking print-mode auth. "
+                            f"{recovery_hint}"
                         ),
-                        details={"command": command},
+                        details={
+                            "command": command,
+                            "recovery_hint": recovery_hint,
+                        },
                     )
                 )
                 continue
@@ -439,6 +456,8 @@ class PreflightRunner:
                 tail = output.splitlines()[-1]
             if tail:
                 message = f"{message} {tail}"
+            recovery_hint = self._claude_recovery_hint(profile_name)
+            message = f"{message} {recovery_hint}"
             checks.append(
                 PreflightCheck(
                     name=f"claude_cli:{profile_name}",
@@ -449,6 +468,7 @@ class PreflightRunner:
                         "exit_code": process.returncode,
                         "stdout": output,
                         "stderr": error_output,
+                        "recovery_hint": recovery_hint,
                     },
                 )
             )

--- a/openclaw_v2/preflight.py
+++ b/openclaw_v2/preflight.py
@@ -373,13 +373,15 @@ class PreflightRunner:
         return env
 
     @staticmethod
-    def _claude_recovery_hint(profile_name: str) -> str:
+    def _claude_recovery_hint(profile_name: str, stderr_text: str = "") -> str:
         hint = (
             "Recovery: if Codex is unavailable, switch to `mission_control_openclaw_default` "
             "and set `OPENCLAW_ASSIGN_IMPLEMENT_LOCAL=openclaw_builder`."
         )
         if profile_name == "claude_local":
             hint += " For triage-only debugging, `OPENCLAW_ASSIGN_TRIAGE_LOCAL=claude_router_isolated` can isolate ANTHROPIC_* env."
+        if profile_name.endswith("_isolated") and ("Not logged in" in stderr_text or "Please run /login" in stderr_text):
+            hint += " The isolated Claude profile is not authenticated here, so the OpenClaw fallback is the practical live path."
         return hint
 
     async def _check_claude_profiles(self, repo_path: str, plan: list[WorkItem]) -> list[PreflightCheck]:
@@ -456,7 +458,7 @@ class PreflightRunner:
                 tail = output.splitlines()[-1]
             if tail:
                 message = f"{message} {tail}"
-            recovery_hint = self._claude_recovery_hint(profile_name)
+            recovery_hint = self._claude_recovery_hint(profile_name, error_output or output)
             message = f"{message} {recovery_hint}"
             checks.append(
                 PreflightCheck(

--- a/openclaw_v2/usage_stats.py
+++ b/openclaw_v2/usage_stats.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from typing import Any
+
+USAGE_FIELDS = ("input", "output", "cacheRead", "cacheWrite", "total")
+
+
+def _empty_usage() -> dict[str, int]:
+    return {field: 0 for field in USAGE_FIELDS}
+
+
+def _usage_payload(value: Any) -> dict[str, int] | None:
+    if not isinstance(value, dict):
+        return None
+
+    payload = _empty_usage()
+    derived_total = 0
+    seen = False
+    saw_total = False
+    for field in USAGE_FIELDS:
+        field_value = value.get(field)
+        if isinstance(field_value, bool) or not isinstance(field_value, int):
+            continue
+        payload[field] += field_value
+        if field != "total":
+            derived_total += field_value
+        else:
+            saw_total = True
+        seen = True
+    if seen and not saw_total:
+        payload["total"] = derived_total
+    return payload if seen else None
+
+
+def _add_usage(total: dict[str, int], usage: dict[str, int]) -> None:
+    for field in USAGE_FIELDS:
+        total[field] += usage[field]
+
+
+def summarize_openclaw_usage(summary: dict[str, Any]) -> dict[str, Any]:
+    results = summary.get("results", [])
+    if not isinstance(results, list):
+        results = []
+
+    result_count = 0
+    usage_count = 0
+    last_call_usage_count = 0
+    usage_totals = _empty_usage()
+    last_call_usage_totals = _empty_usage()
+
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        result_count += 1
+
+        artifacts = item.get("artifacts", {})
+        if not isinstance(artifacts, dict):
+            continue
+
+        usage = _usage_payload(artifacts.get("openclaw_usage"))
+        if usage is not None:
+            _add_usage(usage_totals, usage)
+            usage_count += 1
+
+        last_call_usage = _usage_payload(artifacts.get("openclaw_last_call_usage"))
+        if last_call_usage is not None:
+            _add_usage(last_call_usage_totals, last_call_usage)
+            last_call_usage_count += 1
+
+    return {
+        "resultCount": result_count,
+        "openclawUsageCount": usage_count,
+        "openclawLastCallUsageCount": last_call_usage_count,
+        "openclawUsage": usage_totals,
+        "openclawLastCallUsage": last_call_usage_totals,
+    }
+
+
+def compare_openclaw_usage(left_usage: dict[str, Any], right_usage: dict[str, Any]) -> dict[str, Any]:
+    left = left_usage if isinstance(left_usage, dict) else {}
+    right = right_usage if isinstance(right_usage, dict) else {}
+    left_totals = left.get("openclawUsage", {})
+    right_totals = right.get("openclawUsage", {})
+    left_last_call_totals = left.get("openclawLastCallUsage", {})
+    right_last_call_totals = right.get("openclawLastCallUsage", {})
+    left_result_count = left.get("resultCount", 0)
+    right_result_count = right.get("resultCount", 0)
+    left_usage_count = left.get("openclawUsageCount", 0)
+    right_usage_count = right.get("openclawUsageCount", 0)
+    left_last_call_count = left.get("openclawLastCallUsageCount", 0)
+    right_last_call_count = right.get("openclawLastCallUsageCount", 0)
+
+    return {
+        "resultCountDelta": _int_value(right_result_count) - _int_value(left_result_count),
+        "openclawUsageCountDelta": _int_value(right_usage_count) - _int_value(left_usage_count),
+        "openclawLastCallUsageCountDelta": _int_value(right_last_call_count) - _int_value(left_last_call_count),
+        "openclawUsageTotalDelta": _usage_total(right_totals) - _usage_total(left_totals),
+        "openclawLastCallUsageTotalDelta": _usage_total(right_last_call_totals) - _usage_total(left_last_call_totals),
+        "left": left,
+        "right": right,
+    }
+
+
+def _int_value(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def _usage_total(value: Any) -> int:
+    if not isinstance(value, dict):
+        return 0
+    total = value.get("total")
+    return total if isinstance(total, int) and not isinstance(total, bool) else 0

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -257,6 +257,15 @@ def _selected_steps(payload: dict[str, Any]) -> list[str] | None:
     raise web.HTTPBadRequest(text="steps must be a comma-separated string or a list of step ids.")
 
 
+def _workflow_run_ref(payload: dict[str, Any]) -> str:
+    raw_ref = payload.get("workflowRunRef", payload.get("workflow_run_ref", ""))
+    if raw_ref in ("", None):
+        return ""
+    if not isinstance(raw_ref, str):
+        raise web.HTTPBadRequest(text="workflowRunRef must be a string.")
+    return raw_ref.strip()
+
+
 def _default_openclaw_agent_id(config: Any) -> str:
     env_value = os.getenv("OPENCLAW_AGENT_ID", "").strip()
     if env_value:
@@ -1473,6 +1482,7 @@ def _validate_task_submission(action: str, payload: dict[str, Any], config: Any)
         return
 
     selected_steps = _selected_steps(payload)
+    workflow_run_ref = _workflow_run_ref(payload)
 
     if action == "run":
         user_request = str(payload.get("request", "")).strip()
@@ -1484,6 +1494,7 @@ def _validate_task_submission(action: str, payload: dict[str, Any], config: Any)
         live = False
 
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = workflow_run_ref
     if action == "run" and live:
         _validate_live_policy(
             orchestrator,
@@ -1503,6 +1514,7 @@ async def _execute_dashboard_action(
     payload = task.payload
     repo_path, config_path, config = _resolve_request_payload(app, payload)
     selected_steps = _selected_steps(payload)
+    workflow_run_ref = _workflow_run_ref(payload)
 
     if task.action == "doctor":
         task.add_progress("Running config diagnostics.")
@@ -1514,6 +1526,7 @@ async def _execute_dashboard_action(
         }
 
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = workflow_run_ref
 
     if task.action in {"diagnose", "preflight"}:
         task.add_progress("Running preflight.")
@@ -1538,6 +1551,7 @@ async def _execute_dashboard_action(
     live = _read_json_bool_field(payload, "live", False)
     config.runtime.dry_run = not live
     orchestrator = HybridOrchestrator(config)
+    orchestrator.workflow_run_ref = workflow_run_ref
     if live:
         _validate_live_policy(
             orchestrator,

--- a/openclaw_v2/web.py
+++ b/openclaw_v2/web.py
@@ -20,6 +20,7 @@ from .config import AppConfig, diagnose_app_config, load_app_config, resolve_run
 from .github_support import normalize_github_repo, resolve_github_repo_from_origin
 from .models import TaskStatus
 from .orchestrator import HybridOrchestrator
+from .usage_stats import compare_openclaw_usage, summarize_openclaw_usage
 
 APP_CONFIG_PATH = web.AppKey("config_path", str)
 APP_REPO_PATH = web.AppKey("repo_path", str)
@@ -457,6 +458,7 @@ def _summarize_run_insights(
 ) -> dict[str, Any]:
     results = _summary_results(summary)
     plan = _summary_plan(summary)
+    usage_summary = summarize_openclaw_usage(summary)
     plan_titles = {
         str(item.get("id", "")).strip(): str(item.get("title", "")).strip()
         for item in plan
@@ -660,6 +662,7 @@ def _summarize_run_insights(
             "roles": hermes_roles,
             "checks": hermes_checks,
         },
+        "usage": usage_summary,
     }
 
 
@@ -713,6 +716,8 @@ def _compare_run_histories(left: dict[str, Any], right: dict[str, Any]) -> dict[
     right_latest_failure = _json_object_value(right_github.get("latestFailure"))
     left_hermes = _json_object_value(left_insights.get("hermes"))
     right_hermes = _json_object_value(right_insights.get("hermes"))
+    left_usage = _json_object_value(left_insights.get("usage"))
+    right_usage = _json_object_value(right_insights.get("usage"))
     return {
         "countDiffs": count_diffs,
         "stepDiffs": step_diffs,
@@ -726,6 +731,7 @@ def _compare_run_histories(left: dict[str, Any], right: dict[str, Any]) -> dict[
             "left": left_latest_failure,
             "right": right_latest_failure,
         },
+        "usageDelta": compare_openclaw_usage(left_usage, right_usage),
         "hermesSessionDelta": _json_int_value(right_hermes.get("sessionCount", 0))
         - _json_int_value(left_hermes.get("sessionCount", 0)),
     }

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -339,6 +339,7 @@ function preflightSnapshotStatus(checks) {
       status: "neutral",
       summary: "No preflight snapshot loaded yet.",
       detail: "Run Preflight or load a recent run to surface the last report here.",
+      recoveryHint: "",
     };
   }
 
@@ -355,7 +356,25 @@ function preflightSnapshotStatus(checks) {
       ? `${problems.length} preflight checks need attention.`
       : "Latest preflight snapshot is clean.",
     detail: `${normalized.length} checks captured from the latest snapshot.`,
+    recoveryHint: formatPreflightRecoveryHint(normalized),
   };
+}
+
+function formatPreflightRecoveryHint(checks) {
+  if (!Array.isArray(checks)) {
+    return "";
+  }
+  for (const check of checks) {
+    const message = String(check?.message || "").trim();
+    if (!message) {
+      continue;
+    }
+    const recoveryIndex = message.indexOf("Recovery:");
+    if (recoveryIndex >= 0) {
+      return message.slice(recoveryIndex).trim();
+    }
+  }
+  return "";
 }
 
 function currentHistoryPayload() {
@@ -755,6 +774,7 @@ function renderReadinessGate() {
   const planItems = effectivePlanItems();
   const preflightChecks = latestPreflightChecks();
   const preflight = preflightSnapshotStatus(preflightChecks);
+  const preflightRecovery = formatPreflightRecoveryHint(preflightChecks);
   const allowedLiveSteps = Array.isArray(runtime.allowed_live_steps) ? runtime.allowed_live_steps : [];
   const usesOpenClaw = planItems.some((item) => {
     const mode = String(item.mode || "").toLowerCase();
@@ -899,7 +919,7 @@ function renderReadinessGate() {
       name: "Latest preflight",
       status: preflight.status,
       summary: preflight.summary,
-      detail: preflight.detail,
+      detail: preflightRecovery ? `${preflight.detail} ${preflightRecovery}` : preflight.detail,
     },
   ];
 
@@ -1920,6 +1940,7 @@ function renderHealthSnapshot(payload) {
   renderReadinessGate();
   const channels = payload.channels || [];
   const preflight = preflightSnapshotStatus(latestPreflightChecks());
+  const preflightRecovery = formatPreflightRecoveryHint(latestPreflightChecks());
   const preflightSource = latestPreflightSource();
   const gateway = payload.gateway || {};
   const memory = payload.memory || {};
@@ -1969,6 +1990,7 @@ function renderHealthSnapshot(payload) {
         <div class="meta-list">
           <div><dt>Summary</dt><dd>${escapeHtml(preflight.summary)}</dd></div>
           <div><dt>Detail</dt><dd>${escapeHtml(preflight.detail)}</dd></div>
+          ${preflightRecovery ? `<div><dt>Recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>` : ""}
           <div><dt>Source</dt><dd>${escapeHtml(preflightSource)}</dd></div>
         </div>
       </article>

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -499,6 +499,31 @@ function formatOpenClawUsageDelta(usageDelta) {
   return `OpenClaw usage delta: ${parts.join(" · ")}`;
 }
 
+function formatOpenClawUsageTrend(runs) {
+  if (!Array.isArray(runs)) {
+    return null;
+  }
+  const usageRuns = runs
+    .map((run) => {
+      const totalTokens = Number.isInteger(run?.insights?.usage?.openclawUsage?.total)
+        ? run.insights.usage.openclawUsage.total
+        : null;
+      return totalTokens === null ? null : { run, totalTokens };
+    })
+    .filter(Boolean);
+  if (usageRuns.length < 2) {
+    return null;
+  }
+
+  const latest = usageRuns[0];
+  const previous = usageRuns[1];
+  const delta = latest.totalTokens - previous.totalTokens;
+  return {
+    tone: delta > 0 ? "warning" : delta < 0 ? "passed" : "neutral",
+    text: `Latest ${latest.totalTokens} tokens vs previous ${previous.totalTokens} tokens (${delta >= 0 ? "+" : ""}${delta})`,
+  };
+}
+
 function actionableResults(results) {
   return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
 }
@@ -1741,11 +1766,23 @@ function renderRequestPresets() {
 
 function renderRecentRuns(bootstrap) {
   const runs = bootstrap.recentRuns || [];
+  const usageTrend = formatOpenClawUsageTrend(runs);
   if (!runs.length) {
     elements.recentRuns.innerHTML = `<div class="empty-state">No recorded runs yet.</div>`;
     return;
   }
-  elements.recentRuns.innerHTML = runs
+  const trendMarkup = usageTrend
+    ? `
+      <article class="diff-card">
+        <div class="result-card-header">
+          <strong>OpenClaw usage trend</strong>
+          ${makeStatusChip(usageTrend.tone)}
+        </div>
+        <p>${escapeHtml(usageTrend.text)}</p>
+      </article>
+    `
+    : "";
+  elements.recentRuns.innerHTML = `${trendMarkup}${runs
     .map((run) => {
       const latestFailure = run.insights?.github?.latestFailure || null;
       const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);
@@ -1784,7 +1821,7 @@ function renderRecentRuns(bootstrap) {
         </article>
       `;
     })
-    .join("");
+    .join("")}`;
 
   elements.recentRuns.querySelectorAll("button[data-run-id]").forEach((button) => {
     button.addEventListener("click", () => {

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -34,6 +34,7 @@ const elements = {
   healthAgentId: document.getElementById("health-agent-id"),
   checkHealth: document.getElementById("check-health"),
   healthPanel: document.getElementById("health-panel"),
+  workflowRunRef: document.getElementById("workflow-run-ref"),
   taskState: document.getElementById("task-state"),
   cancelTask: document.getElementById("cancel-task"),
   taskMeta: document.getElementById("task-meta"),
@@ -400,6 +401,7 @@ function setCopyFeedback(message) {
 
 function updateActionButtons() {
   const requestReady = Boolean((elements.request.value || "").trim());
+  const workflowRunRefIsReady = workflowRunRefReady();
   const taskActive = ["queued", "running"].includes(state.currentTaskStatus);
   elements.buttons.forEach((button) => {
     if (taskActive) {
@@ -407,7 +409,7 @@ function updateActionButtons() {
       return;
     }
     if (button.dataset.action === "run") {
-      button.disabled = !requestReady;
+      button.disabled = !requestReady || !workflowRunRefIsReady;
       return;
     }
     button.disabled = false;
@@ -644,6 +646,9 @@ function renderReadinessGate() {
   const health = state.healthSnapshot;
   const healthCurrent = healthSnapshotIsCurrent();
   const requestText = (elements.request.value || "").trim();
+  const workflowRunRefValue = currentWorkflowRunRef();
+  const workflowRunRefRequired = pipelineRequiresWorkflowRunRef();
+  const workflowRunRefIsReady = workflowRunRefReady();
   const pipelineSteps = currentPipelineSteps();
   const explicitSelection = selectedSteps();
   const effectiveIds = effectiveStepIds();
@@ -685,6 +690,22 @@ function renderReadinessGate() {
           ? "Live mode requires an explicit subset."
           : `Pipeline: ${elements.pipeline.value || bootstrap.snapshot?.defaultPipeline || "n/a"}`
         : "Refresh bootstrap or check config_v2.yaml.",
+    },
+    {
+      name: "Workflow run ref",
+      status: !workflowRunRefRequired
+        ? "neutral"
+        : workflowRunRefIsReady
+          ? "passed"
+          : "blocked",
+      summary: !workflowRunRefRequired
+        ? "Selected route does not require an existing workflow run reference."
+        : workflowRunRefIsReady
+          ? "Resume workflow reference is ready."
+          : "Provide a GitHub workflow run reference before launching this pipeline.",
+      detail: !workflowRunRefRequired
+        ? "No resume-only step is in the active route."
+        : workflowRunRefValue || "workflowRunRef is missing.",
     },
     {
       name: "Live policy",
@@ -1437,6 +1458,26 @@ function selectedSteps() {
   );
 }
 
+function currentWorkflowRunRef() {
+  return String(elements.workflowRunRef.value || "").trim();
+}
+
+function pipelineRequiresWorkflowRunRef() {
+  const pipelineSteps = currentPipelineSteps();
+  if (!pipelineSteps.length) {
+    return false;
+  }
+  const effectiveIds = new Set(effectiveStepIds());
+  return pipelineSteps.some(
+    (step) =>
+      Boolean(step?.metadata?.requires_external_workflow_run_ref) && effectiveIds.has(step.id),
+  );
+}
+
+function workflowRunRefReady() {
+  return !pipelineRequiresWorkflowRunRef() || Boolean(currentWorkflowRunRef());
+}
+
 function renderWorkspaceMetrics(bootstrap) {
   const git = bootstrap.git || {};
   const snapshot = bootstrap.snapshot || {};
@@ -1560,6 +1601,7 @@ function renderStepGrid() {
       renderPipelineDag();
       renderHeroStatus();
       renderReadinessGate();
+      updateActionButtons();
     });
   });
 }
@@ -2329,6 +2371,7 @@ function taskPayload(action) {
     repoPath: elements.repoPath.value,
     configPath: elements.configPath.value,
     pipeline: elements.pipeline.value,
+    workflowRunRef: currentWorkflowRunRef(),
     request: elements.request.value,
     steps: selectedSteps(),
     live: state.live,
@@ -2431,6 +2474,12 @@ function bindEvents() {
     renderReadinessGate();
   });
 
+  elements.workflowRunRef.addEventListener("input", () => {
+    renderLaunchBrief();
+    renderReadinessGate();
+    updateActionButtons();
+  });
+
   elements.compareLeftRun.addEventListener("change", () => {
     loadRunCompare().catch((error) => {
       elements.runCompare.innerHTML = `<div class="empty-state">${escapeHtml(error.message)}</div>`;
@@ -2501,6 +2550,7 @@ function bindEvents() {
     renderPipelineDag();
     renderHeroStatus();
     renderReadinessGate();
+    updateActionButtons();
   });
 
   elements.selectNone.addEventListener("click", () => {
@@ -2512,6 +2562,7 @@ function bindEvents() {
     renderPipelineDag();
     renderHeroStatus();
     renderReadinessGate();
+    updateActionButtons();
   });
 
   elements.buttons.forEach((button) => {

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -524,6 +524,14 @@ function formatOpenClawUsageTrend(runs) {
   };
 }
 
+function currentOpenClawUsage() {
+  const runPayload = extractRunPayload(state.currentOutput);
+  if (!runPayload) {
+    return null;
+  }
+  return runPayload.history?.insights?.usage || runPayload.insights?.usage || null;
+}
+
 function actionableResults(results) {
   return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
 }
@@ -2210,6 +2218,7 @@ function generateRunSummaryText() {
   const counts = formatCounts(statusCounts(results));
   const actionable = actionableResults(results);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
     `Run ID: ${runResult.run_id || "n/a"}`,
     `Pipeline: ${runPayload.pipeline || "n/a"}`,
@@ -2220,6 +2229,9 @@ function generateRunSummaryText() {
     formatReviewWorkflowLine(workflow),
     `Status counts: ${counts}`,
   ];
+  if (usageLine) {
+    lines.push(usageLine);
+  }
   if (recoveryLine) {
     lines.push(recoveryLine);
   }
@@ -2244,6 +2256,7 @@ function generateIssueUpdateText() {
   const results = runResult.results || [];
   const actionable = actionableResults(results);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
     "OpenClaw progress update",
     "",
@@ -2255,6 +2268,9 @@ function generateIssueUpdateText() {
     `- ${formatReviewWorkflowLine(workflow)}`,
     `- Status counts: ${formatCounts(statusCounts(results))}`,
   ];
+  if (usageLine) {
+    lines.push(`- ${usageLine}`);
+  }
   if (recoveryLine) {
     lines.push(`- ${recoveryLine}`);
   }
@@ -2283,6 +2299,7 @@ function generatePrNoteText() {
     .map((fact) => `${fact.label}:${fact.value}`)
     .join(" · ");
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
     "PR-ready note",
     "",
@@ -2295,6 +2312,9 @@ function generatePrNoteText() {
     formatReviewWorkflowLine(workflow),
     `Status counts: ${formatCounts(statusCounts(runResult.results || []))}`,
   ];
+  if (usageLine) {
+    lines.push(usageLine);
+  }
   if (recoveryLine) {
     lines.push(recoveryLine);
   }

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -377,6 +377,15 @@ function formatPreflightRecoveryHint(checks) {
   return "";
 }
 
+function currentPreflightRecoveryHint() {
+  return formatPreflightRecoveryHint(latestPreflightChecks());
+}
+
+function formatPreflightRecoveryLine(preflightRecovery) {
+  const hint = String(preflightRecovery || "").trim();
+  return hint ? `Preflight recovery: ${hint}` : "";
+}
+
 function currentHistoryPayload() {
   if (state.currentHistory) {
     return state.currentHistory;
@@ -1940,7 +1949,7 @@ function renderHealthSnapshot(payload) {
   renderReadinessGate();
   const channels = payload.channels || [];
   const preflight = preflightSnapshotStatus(latestPreflightChecks());
-  const preflightRecovery = formatPreflightRecoveryHint(latestPreflightChecks());
+  const preflightRecovery = currentPreflightRecoveryHint();
   const preflightSource = latestPreflightSource();
   const gateway = payload.gateway || {};
   const memory = payload.memory || {};
@@ -2133,6 +2142,7 @@ function renderRunResults(runResult, insights = null) {
   const failureLine = formatGitHubFailureLine(failure);
   const failureSummary = formatGitHubFailureSummary(failure);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const preflightRecovery = currentPreflightRecoveryHint();
   const usageLine = formatOpenClawUsageSummary(insights?.usage || null);
   const results = runResult.results || [];
   const visibleResults = filterResults(results);
@@ -2208,6 +2218,7 @@ function renderRunResults(runResult, insights = null) {
           <div><dt>Results</dt><dd>${escapeHtml(String(results.length))}</dd></div>
           <div><dt>Status counts</dt><dd>${escapeHtml(formatCounts(counts))}</dd></div>
           <div><dt>Visible filter</dt><dd>${escapeHtml(state.resultFilter)}</dd></div>
+          ${preflightRecovery ? `<div><dt>Preflight recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>` : ""}
           <div><dt>GitHub latest failure</dt><dd>${escapeHtml(failureLine)}</dd></div>
           ${usageLine ? `<div><dt>OpenClaw usage</dt><dd>${escapeHtml(usageLine)}</dd></div>` : ""}
         </dl>
@@ -2239,6 +2250,7 @@ function generateRunSummaryText() {
   const results = runResult.results || [];
   const counts = formatCounts(statusCounts(results));
   const actionable = actionableResults(results);
+  const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
   const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
@@ -2253,6 +2265,9 @@ function generateRunSummaryText() {
   ];
   if (usageLine) {
     lines.push(usageLine);
+  }
+  if (preflightRecoveryLine) {
+    lines.push(preflightRecoveryLine);
   }
   if (recoveryLine) {
     lines.push(recoveryLine);
@@ -2277,6 +2292,7 @@ function generateIssueUpdateText() {
   const failure = currentGitHubFailure();
   const results = runResult.results || [];
   const actionable = actionableResults(results);
+  const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
   const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
@@ -2292,6 +2308,9 @@ function generateIssueUpdateText() {
   ];
   if (usageLine) {
     lines.push(`- ${usageLine}`);
+  }
+  if (preflightRecoveryLine) {
+    lines.push(`- ${preflightRecoveryLine}`);
   }
   if (recoveryLine) {
     lines.push(`- ${recoveryLine}`);
@@ -2320,6 +2339,7 @@ function generatePrNoteText() {
   const readiness = readinessFacts()
     .map((fact) => `${fact.label}:${fact.value}`)
     .join(" · ");
+  const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
   const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());
   const lines = [
@@ -2336,6 +2356,9 @@ function generatePrNoteText() {
   ];
   if (usageLine) {
     lines.push(usageLine);
+  }
+  if (preflightRecoveryLine) {
+    lines.push(preflightRecoveryLine);
   }
   if (recoveryLine) {
     lines.push(recoveryLine);

--- a/openclaw_v2/webui/app.js
+++ b/openclaw_v2/webui/app.js
@@ -432,6 +432,73 @@ function formatCounts(counts) {
   return entries.map(([key, value]) => `${key}:${value}`).join(" · ");
 }
 
+function formatOpenClawUsageSummary(usage) {
+  if (!usage || typeof usage !== "object") {
+    return "";
+  }
+  const resultCount = Number.isInteger(usage.resultCount) ? usage.resultCount : 0;
+  const usageCount = Number.isInteger(usage.openclawUsageCount) ? usage.openclawUsageCount : 0;
+  const lastCallCount = Number.isInteger(usage.openclawLastCallUsageCount)
+    ? usage.openclawLastCallUsageCount
+    : 0;
+  const totalTokens = Number.isInteger(usage.openclawUsage?.total) ? usage.openclawUsage.total : 0;
+  const lastCallTokens = Number.isInteger(usage.openclawLastCallUsage?.total)
+    ? usage.openclawLastCallUsage.total
+    : 0;
+  if (!usageCount && !lastCallCount && !totalTokens && !lastCallTokens) {
+    return "";
+  }
+
+  const parts = [];
+  const resultLabel = resultCount ? `${usageCount}/${resultCount} results with usage` : `${usageCount} results with usage`;
+  parts.push(resultLabel);
+  if (totalTokens) {
+    parts.push(`total ${totalTokens} tokens`);
+  }
+  if (lastCallCount) {
+    parts.push(`${lastCallCount} last-call ${lastCallCount === 1 ? "sample" : "samples"}`);
+  }
+  if (lastCallTokens) {
+    parts.push(`last call ${lastCallTokens} tokens`);
+  }
+  return `OpenClaw usage: ${parts.join(" · ")}`;
+}
+
+function formatOpenClawUsageDelta(usageDelta) {
+  if (!usageDelta || typeof usageDelta !== "object") {
+    return "";
+  }
+  const left = usageDelta.left || {};
+  const right = usageDelta.right || {};
+  const leftResultCount = Number.isInteger(left.resultCount) ? left.resultCount : 0;
+  const rightResultCount = Number.isInteger(right.resultCount) ? right.resultCount : 0;
+  const leftUsageTotal = Number.isInteger(left.openclawUsage?.total) ? left.openclawUsage.total : 0;
+  const rightUsageTotal = Number.isInteger(right.openclawUsage?.total) ? right.openclawUsage.total : 0;
+  const leftLastCallTotal = Number.isInteger(left.openclawLastCallUsage?.total)
+    ? left.openclawLastCallUsage.total
+    : 0;
+  const rightLastCallTotal = Number.isInteger(right.openclawLastCallUsage?.total)
+    ? right.openclawLastCallUsage.total
+    : 0;
+
+  const parts = [];
+  if (leftResultCount || rightResultCount) {
+    parts.push(`results ${leftResultCount}→${rightResultCount} (${rightResultCount - leftResultCount >= 0 ? "+" : ""}${rightResultCount - leftResultCount})`);
+  }
+  if (leftUsageTotal || rightUsageTotal) {
+    const delta = rightUsageTotal - leftUsageTotal;
+    parts.push(`tokens ${leftUsageTotal}→${rightUsageTotal} (${delta >= 0 ? "+" : ""}${delta})`);
+  }
+  if (leftLastCallTotal || rightLastCallTotal) {
+    const delta = rightLastCallTotal - leftLastCallTotal;
+    parts.push(`last-call ${leftLastCallTotal}→${rightLastCallTotal} (${delta >= 0 ? "+" : ""}${delta})`);
+  }
+  if (!parts.length) {
+    return "";
+  }
+  return `OpenClaw usage delta: ${parts.join(" · ")}`;
+}
+
 function actionableResults(results) {
   return (results || []).filter((item) => ["failed", "blocked", "skipped"].includes(item.status));
 }
@@ -1335,12 +1402,14 @@ function renderRunCompare(payload) {
   const runs = payload.runs || [];
   const comparison = payload.comparison || {};
   const latestFailures = comparison.latestFailures || {};
+  const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);
   elements.runCompare.innerHTML = `
     <div class="compare-grid">
       ${runs
         .map(
           (run) => {
             const latestFailure = run.insights?.github?.latestFailure || null;
+            const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);
             const failureRecovery = formatGitHubRecoveryLine(null, latestFailure);
             const failureSummary = formatGitHubFailureSummary(latestFailure);
             return `
@@ -1363,6 +1432,7 @@ function renderRunCompare(payload) {
                 <small>${escapeHtml(formatGitHubFailureLine(run.insights?.github?.latestFailure || null))}</small>
                 ${failureSummary ? `<small>${escapeHtml(failureSummary)}</small>` : ""}
                 ${failureRecovery ? `<small>${escapeHtml(failureRecovery)}</small>` : ""}
+                ${usageLine ? `<small>${escapeHtml(usageLine)}</small>` : ""}
                 <small>${escapeHtml(`Hermes sessions: ${run.insights?.hermes?.sessionCount || 0}`)}</small>
               </article>
             `;
@@ -1384,6 +1454,19 @@ function renderRunCompare(payload) {
         </div>
         <small>${escapeHtml(`Branch changed: ${comparison.branchChanged ? "yes" : "no"} · Workflow changed: ${comparison.workflowChanged ? "yes" : "no"} · Hermes session delta: ${comparison.hermesSessionDelta || 0}`)}</small>
       </article>
+      ${
+        usageDeltaLine
+          ? `
+            <article class="diff-card">
+              <div class="result-card-header">
+                <strong>OpenClaw usage delta</strong>
+                ${makeStatusChip("warning")}
+              </div>
+              <p>${escapeHtml(usageDeltaLine)}</p>
+            </article>
+          `
+          : ""
+      }
       <article class="diff-card">
         <div class="result-card-header">
           <strong>GitHub failure delta</strong>
@@ -1665,6 +1748,7 @@ function renderRecentRuns(bootstrap) {
   elements.recentRuns.innerHTML = runs
     .map((run) => {
       const latestFailure = run.insights?.github?.latestFailure || null;
+      const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);
       const failureRecovery = formatGitHubRecoveryLine(null, latestFailure);
       const failureSummary = formatGitHubFailureSummary(latestFailure);
       const recentRunStatus =
@@ -1691,6 +1775,7 @@ function renderRecentRuns(bootstrap) {
           <small>${escapeHtml(formatGitHubFailureLine(run.insights?.github?.latestFailure || null))}</small>
           ${failureSummary ? `<small>${escapeHtml(failureSummary)}</small>` : ""}
           ${failureRecovery ? `<small>${escapeHtml(`Recovery: ${failureRecovery}`)}</small>` : ""}
+          ${usageLine ? `<small>${escapeHtml(usageLine)}</small>` : ""}
           <small>${escapeHtml(formatAbsoluteTime(run.updatedAt))}</small>
           <div class="task-controls">
             <button class="ghost-button" type="button" data-run-id="${escapeHtml(run.runId)}">Load summary</button>
@@ -1975,12 +2060,13 @@ function renderPlan(plan) {
   `;
 }
 
-function renderRunResults(runResult) {
+function renderRunResults(runResult, insights = null) {
   const workflow = currentGitHubWorkflow();
   const failure = currentGitHubFailure();
   const failureLine = formatGitHubFailureLine(failure);
   const failureSummary = formatGitHubFailureSummary(failure);
   const recoveryLine = formatGitHubRecoveryLine(workflow, failure);
+  const usageLine = formatOpenClawUsageSummary(insights?.usage || null);
   const results = runResult.results || [];
   const visibleResults = filterResults(results);
   const counts = statusCounts(results);
@@ -2056,6 +2142,7 @@ function renderRunResults(runResult) {
           <div><dt>Status counts</dt><dd>${escapeHtml(formatCounts(counts))}</dd></div>
           <div><dt>Visible filter</dt><dd>${escapeHtml(state.resultFilter)}</dd></div>
           <div><dt>GitHub latest failure</dt><dd>${escapeHtml(failureLine)}</dd></div>
+          ${usageLine ? `<div><dt>OpenClaw usage</dt><dd>${escapeHtml(usageLine)}</dd></div>` : ""}
         </dl>
         ${failureSummary ? `<small>${escapeHtml(failureSummary)}</small>` : ""}
         ${recoveryLine ? `<small>${escapeHtml(`Recovery: ${recoveryLine}`)}</small>` : ""}
@@ -2191,10 +2278,10 @@ function renderOutput(payload) {
     chunks.push(renderChecks(payload.preflight.checks));
   }
   if (payload.runResult) {
-    chunks.push(renderRunResults(payload.runResult));
+    chunks.push(renderRunResults(payload.runResult, payload.history?.insights || payload.insights || null));
   }
   if (payload.summary) {
-    chunks.push(renderRunResults(payload.summary));
+    chunks.push(renderRunResults(payload.summary, payload.insights || null));
   }
   elements.outputPane.innerHTML = chunks.join("") || `<div class="empty-state">No output captured.</div>`;
   if (payload.history) {

--- a/openclaw_v2/webui/index.html
+++ b/openclaw_v2/webui/index.html
@@ -142,6 +142,20 @@
               <select id="pipeline" name="pipeline"></select>
             </label>
 
+            <label class="field field-full">
+              <span>Workflow run ref</span>
+              <input
+                id="workflow-run-ref"
+                name="workflowRunRef"
+                type="text"
+                autocomplete="off"
+                placeholder="Run id or run URL"
+              />
+              <small class="subtle">
+                Resume an existing GitHub Actions workflow run when the selected pipeline needs one.
+              </small>
+            </label>
+
             <label class="field toggle-field">
               <span>Mode</span>
               <button id="mode-toggle" type="button" class="mode-toggle" aria-pressed="false">

--- a/tests/test_main_v2.py
+++ b/tests/test_main_v2.py
@@ -466,6 +466,47 @@ class MainV2WebModeTests(unittest.IsolatedAsyncioTestCase):
             port=9900,
         )
 
+    async def test_main_passes_workflow_run_ref_to_orchestrator(self) -> None:
+        captured: dict[str, object] = {}
+
+        class FakeOrchestrator:
+            def __init__(self, config) -> None:
+                self.config = config
+                self.workflow_run_ref = ""
+
+            async def run(self, user_input, repo_path, selected_steps=None, progress_callback=None):
+                captured["workflow_run_ref"] = self.workflow_run_ref
+                captured["selected_steps"] = selected_steps
+                return RunResult(
+                    run_id="run-resume",
+                    plan=[],
+                    results=[],
+                    success=True,
+                    artifacts_dir="/tmp/run-resume",
+                )
+
+        with (
+            mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "main_v2.py",
+                    "--request",
+                    "Resume review collection",
+                    "--steps",
+                    "collect_review",
+                    "--workflow-run-ref",
+                    "25504962543",
+                ],
+            ),
+            mock.patch("main_v2.HybridOrchestrator", FakeOrchestrator),
+            mock.patch("builtins.input", side_effect=AssertionError("request mode should not prompt")),
+        ):
+            await main()
+
+        self.assertEqual(captured["workflow_run_ref"], "25504962543")
+        self.assertEqual(captured["selected_steps"], ["collect_review"])
+
     async def test_main_rejects_web_with_request(self) -> None:
         class FakeOrchestrator:
             def __init__(self, config) -> None:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -374,6 +374,69 @@ class OrchestratorExecutionTests(unittest.IsolatedAsyncioTestCase):
         )
         prepare.assert_not_awaited()
 
+    def test_resume_collect_review_plan_requires_an_explicit_workflow_run_ref(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "github_collect_review_resume"
+        orchestrator = HybridOrchestrator(config)
+
+        plan = orchestrator.build_plan()
+
+        self.assertEqual([item.id for item in plan], ["collect_review"])
+        self.assertEqual(plan[0].depends_on, [])
+        self.assertEqual(plan[0].metadata["requires_external_workflow_run_ref"], True)
+        self.assertIn("workflow run reference", plan[0].planning_blocked_reason)
+
+    async def test_resume_collect_review_keeps_injected_workflow_run_ref_through_execution(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "github_collect_review_resume"
+        orchestrator = HybridOrchestrator(config)
+        orchestrator.workflow_run_ref = "25504962543"
+
+        plan = orchestrator.build_plan()
+        self.assertEqual(plan[0].metadata["primary_workflow_run_ref"], "25504962543")
+        self.assertEqual(plan[0].planning_blocked_reason, "")
+
+        context = ExecutionContext(
+            run_id="run-resume",
+            user_request="Resume workflow review collection.",
+            repo_path=os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+            dry_run=False,
+            artifacts_dir="/tmp/artifacts",
+            worktrees_dir="/tmp/worktrees",
+        )
+
+        async def prepare(work_item: WorkItem, execution_context: ExecutionContext) -> None:
+            work_item.workspace_path = execution_context.repo_path
+
+        async def execute_github(
+            work_item: WorkItem,
+            profile,
+            execution_context: ExecutionContext,
+            rendered_prompt: str,
+        ) -> AgentResult:
+            self.assertEqual(work_item.metadata["primary_workflow_run_ref"], "25504962543")
+            self.assertIn("25504962543", rendered_prompt)
+            self.assertIn("最新状态", rendered_prompt)
+            return AgentResult(
+                work_item_id=work_item.id,
+                profile=work_item.profile,
+                agent=work_item.agent,
+                mode=work_item.mode,
+                status=TaskStatus.SUCCEEDED,
+                summary="Workflow status collected.",
+            )
+
+        with (
+            mock.patch.object(orchestrator.worktree_manager, "prepare", new=mock.AsyncMock(side_effect=prepare)),
+            mock.patch.object(orchestrator.artifact_store, "write_workspace_manifest"),
+            mock.patch.object(orchestrator.artifact_store, "write_prompt", return_value="/tmp/prompt.txt"),
+            mock.patch.object(orchestrator.artifact_store, "write_result"),
+        ):
+            orchestrator.executors[ExecutionMode.GITHUB].execute = mock.AsyncMock(side_effect=execute_github)
+            results = await orchestrator._execute_ready_items(plan, context, {})
+
+        self.assertEqual(results[0].status, TaskStatus.SUCCEEDED)
+
     async def test_run_emits_progress_messages_for_dry_run_step(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.dry_run = True

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -296,6 +296,21 @@ class PipelineConfigTests(unittest.TestCase):
         self.assertEqual(work_items["collect_review"].managed_agent, "github_review_followup_bridge")
         self.assertEqual(work_items["collect_review"].depends_on, ["dispatch_review"])
 
+    def test_github_collect_review_resume_pipeline_only_contains_collect_review_step(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.pipeline = "github_collect_review_resume"
+        planner = PipelinePlanner(config)
+
+        plan = planner.build_plan()
+        work_items = {item.id: item for item in plan}
+
+        self.assertEqual(list(work_items.keys()), ["collect_review"])
+        self.assertEqual(work_items["collect_review"].mode, ExecutionMode.GITHUB)
+        self.assertEqual(work_items["collect_review"].assignment, "collect_review_bridge")
+        self.assertEqual(work_items["collect_review"].managed_agent, "github_review_followup_bridge")
+        self.assertEqual(work_items["collect_review"].depends_on, [])
+        self.assertTrue(work_items["collect_review"].metadata["requires_external_workflow_run_ref"])
+
     def test_all_named_pipelines_build_without_duplicate_step_ids(self) -> None:
         config = load_app_config("config_v2.yaml")
 
@@ -306,6 +321,7 @@ class PipelineConfigTests(unittest.TestCase):
             "mission_control_openclaw_default",
             "mission_control_hermes_supervised",
             "github_bridge_smoke",
+            "github_collect_review_resume",
         ]:
             config.runtime.pipeline = pipeline_name
             planner = PipelinePlanner(config)

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -146,6 +146,57 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[1].status, CheckStatus.PASSED)
         self.assertIn("isolated from the repository root", checks[1].message)
 
+    async def test_claude_cli_probe_passes_when_print_mode_succeeds(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(0, "READY\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.PASSED)
+        self.assertIn("passed a print-mode probe", checks[0].message)
+
+    async def test_claude_cli_probe_reports_auth_failure_early(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local_isolated",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(1, "Not logged in · Please run /login\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("Claude CLI probe failed", checks[0].message)
+        self.assertIn("Not logged in", checks[0].message)
+
     async def test_openclaw_missing_agent_id_lists_available_agents(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.profiles["openclaw_local"].openclaw_agent_id = ""

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import tempfile
@@ -18,6 +19,9 @@ class _FakeProcess:
 
     async def communicate(self):
         return self._stdout, self._stderr
+
+    def kill(self) -> None:
+        return None
 
 
 class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
@@ -196,6 +200,62 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(checks[0].status, CheckStatus.FAILED)
         self.assertIn("Claude CLI probe failed", checks[0].message)
         self.assertIn("Not logged in", checks[0].message)
+
+    async def test_claude_cli_probe_suggests_openclaw_fallback_path(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(1, "", "Not logged in · Please run /login\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("openclaw_builder", checks[0].message)
+        self.assertIn("mission_control_openclaw_default", checks[0].message)
+
+    async def test_claude_cli_probe_timeout_suggests_openclaw_fallback_path(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(0, "")),
+            ):
+                with mock.patch(
+                    "openclaw_v2.preflight.asyncio.wait_for",
+                    side_effect=asyncio.TimeoutError,
+                ):
+                    checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("openclaw_builder", checks[0].message)
+        self.assertIn("mission_control_openclaw_default", checks[0].message)
 
     async def test_openclaw_missing_agent_id_lists_available_agents(self) -> None:
         config = load_app_config("config_v2.yaml")

--- a/tests/test_preflight.py
+++ b/tests/test_preflight.py
@@ -227,6 +227,32 @@ class PreflightOpenClawTests(unittest.IsolatedAsyncioTestCase):
         self.assertIn("openclaw_builder", checks[0].message)
         self.assertIn("mission_control_openclaw_default", checks[0].message)
 
+    async def test_claude_isolated_probe_uses_openclaw_fallback_when_not_logged_in(self) -> None:
+        config = load_app_config("config_v2.yaml")
+        config.runtime.dry_run = False
+        runner = PreflightRunner(config)
+        plan = [
+            WorkItem(
+                id="triage",
+                title="Triage user request",
+                profile="claude_local_isolated",
+                agent=AgentType.CLAUDE,
+                mode=ExecutionMode.CLI,
+                prompt_template="",
+            )
+        ]
+
+        with mock.patch("openclaw_v2.preflight.shutil.which", return_value="/usr/bin/claude"):
+            with mock.patch(
+                "openclaw_v2.preflight.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=_FakeProcess(1, "", "Not logged in · Please run /login\n")),
+            ):
+                checks = await runner._check_claude_profiles("/tmp/repo", plan)
+
+        self.assertEqual(checks[0].status, CheckStatus.FAILED)
+        self.assertIn("claude_local_isolated", checks[0].message)
+        self.assertIn("OpenClaw fallback is the practical live path", checks[0].message)
+
     async def test_claude_cli_probe_timeout_suggests_openclaw_fallback_path(self) -> None:
         config = load_app_config("config_v2.yaml")
         config.runtime.dry_run = False

--- a/tests/test_usage_stats.py
+++ b/tests/test_usage_stats.py
@@ -1,0 +1,138 @@
+import unittest
+
+from openclaw_v2.usage_stats import compare_openclaw_usage, summarize_openclaw_usage
+
+
+class UsageStatsTests(unittest.TestCase):
+    def test_summarize_openclaw_usage_accumulates_summary_json_results(self) -> None:
+        summary = {
+            "results": [
+                {
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 120,
+                            "output": 40,
+                            "cacheRead": 800,
+                            "cacheWrite": 0,
+                            "total": 160,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 12,
+                            "output": 4,
+                            "cacheRead": 80,
+                            "total": 16,
+                        },
+                    },
+                },
+                {
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 80,
+                            "output": 30,
+                            "cacheRead": 200,
+                            "cacheWrite": 10,
+                            "total": 110,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 8,
+                            "output": 3,
+                            "cacheRead": 20,
+                            "cacheWrite": 1,
+                            "total": 11,
+                        },
+                    },
+                },
+                "ignore-me",
+            ],
+        }
+
+        usage = summarize_openclaw_usage(summary)
+
+        self.assertEqual(usage["resultCount"], 2)
+        self.assertEqual(usage["openclawUsageCount"], 2)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 2)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 200,
+                "output": 70,
+                "cacheRead": 1000,
+                "cacheWrite": 10,
+                "total": 270,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 20,
+                "output": 7,
+                "cacheRead": 100,
+                "cacheWrite": 1,
+                "total": 27,
+            },
+        )
+
+    def test_summarize_openclaw_usage_tolerates_missing_and_malformed_fields(self) -> None:
+        summary = {
+            "results": [
+                {"artifacts": {"openclaw_usage": {"input": "bad", "total": 20}}},
+                {"artifacts": {"openclaw_usage": None, "openclaw_last_call_usage": {"cacheRead": 5}}},
+                {"artifacts": []},
+            ]
+        }
+
+        usage = summarize_openclaw_usage(summary)
+
+        self.assertEqual(usage["resultCount"], 3)
+        self.assertEqual(usage["openclawUsageCount"], 1)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 1)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "total": 20,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 5,
+                "cacheWrite": 0,
+                "total": 5,
+            },
+        )
+
+    def test_compare_openclaw_usage_calculates_deltas(self) -> None:
+        left = {
+            "resultCount": 2,
+            "openclawUsageCount": 1,
+            "openclawLastCallUsageCount": 1,
+            "openclawUsage": {"input": 10, "output": 4, "cacheRead": 8, "cacheWrite": 1, "total": 14},
+            "openclawLastCallUsage": {"input": 3, "output": 1, "cacheRead": 2, "cacheWrite": 0, "total": 4},
+        }
+        right = {
+            "resultCount": 4,
+            "openclawUsageCount": 3,
+            "openclawLastCallUsageCount": 2,
+            "openclawUsage": {"input": 30, "output": 12, "cacheRead": 18, "cacheWrite": 5, "total": 42},
+            "openclawLastCallUsage": {"input": 6, "output": 2, "cacheRead": 4, "cacheWrite": 1, "total": 8},
+        }
+
+        comparison = compare_openclaw_usage(left, right)
+
+        self.assertEqual(comparison["resultCountDelta"], 2)
+        self.assertEqual(comparison["openclawUsageCountDelta"], 2)
+        self.assertEqual(comparison["openclawLastCallUsageCountDelta"], 1)
+        self.assertEqual(comparison["openclawUsageTotalDelta"], 28)
+        self.assertEqual(comparison["openclawLastCallUsageTotalDelta"], 4)
+        self.assertEqual(comparison["left"], left)
+        self.assertEqual(comparison["right"], right)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -118,6 +118,52 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("envPath", payload["integrations"]["hermes"])
         self.assertNotIn("managedAgents", payload["snapshot"])
         self.assertNotIn("assignments", payload["snapshot"])
+
+    async def test_bootstrap_recent_runs_include_openclaw_usage_summary(self) -> None:
+        run_dir = os.path.join(self.repo_path, ".openclaw", "runs", "run-usage")
+        os.makedirs(run_dir, exist_ok=True)
+        with open(os.path.join(run_dir, "summary.json"), "w", encoding="utf-8") as handle:
+            json.dump(
+                {
+                    "run_id": "run-usage",
+                    "plan": [],
+                    "results": [
+                        {
+                            "work_item_id": "triage",
+                            "status": "succeeded",
+                            "artifacts": {
+                                "openclaw_usage": {
+                                    "input": 80,
+                                    "output": 20,
+                                    "cacheRead": 400,
+                                    "total": 100,
+                                },
+                                "openclaw_last_call_usage": {
+                                    "input": 8,
+                                    "output": 2,
+                                    "cacheRead": 40,
+                                    "total": 10,
+                                },
+                            },
+                        }
+                    ],
+                    "success": True,
+                },
+                handle,
+            )
+
+        response = await self.client.get("/api/bootstrap")
+        self.assertEqual(response.status, 200)
+        payload = await response.json()
+        recent = payload["recentRuns"][0]
+        usage = recent["insights"]["usage"]
+        self.assertEqual(recent["runId"], "run-usage")
+        self.assertEqual(usage["resultCount"], 1)
+        self.assertEqual(usage["openclawUsageCount"], 1)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 1)
+        self.assertEqual(usage["openclawUsage"]["total"], 100)
+        self.assertEqual(usage["openclawLastCallUsage"]["total"], 10)
+
     async def test_index_serves_readiness_and_output_controls(self) -> None:
         response = await self.client.get("/")
         self.assertEqual(response.status, 200)
@@ -804,7 +850,21 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
                             "work_item_id": "publish_branch",
                             "status": "succeeded",
                             "mode": "cli",
-                            "artifacts": {"source_branch": "branch-a"},
+                            "artifacts": {
+                                "source_branch": "branch-a",
+                                "openclaw_usage": {
+                                    "input": 10,
+                                    "output": 4,
+                                    "cacheRead": 100,
+                                    "total": 14,
+                                },
+                                "openclaw_last_call_usage": {
+                                    "input": 3,
+                                    "output": 1,
+                                    "cacheRead": 20,
+                                    "total": 4,
+                                },
+                            },
                         },
                         {
                             "work_item_id": "draft_pr",
@@ -838,7 +898,23 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
                             "work_item_id": "publish_branch",
                             "status": "blocked",
                             "mode": "cli",
-                            "artifacts": {"source_branch": "branch-b"},
+                            "artifacts": {
+                                "source_branch": "branch-b",
+                                "openclaw_usage": {
+                                    "input": 30,
+                                    "output": 12,
+                                    "cacheRead": 300,
+                                    "cacheWrite": 5,
+                                    "total": 47,
+                                },
+                                "openclaw_last_call_usage": {
+                                    "input": 6,
+                                    "output": 2,
+                                    "cacheRead": 40,
+                                    "cacheWrite": 1,
+                                    "total": 9,
+                                },
+                            },
                         },
                         {
                             "work_item_id": "draft_pr",
@@ -872,6 +948,8 @@ class WebBootstrapTests(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(payload["comparison"]["branchChanged"])
         self.assertTrue(payload["comparison"]["latestFailureChanged"])
         self.assertEqual(payload["comparison"]["hermesSessionDelta"], 1)
+        self.assertEqual(payload["comparison"]["usageDelta"]["openclawUsageTotalDelta"], 33)
+        self.assertEqual(payload["comparison"]["usageDelta"]["openclawLastCallUsageTotalDelta"], 5)
         self.assertTrue(any(item["stepId"] == "publish_branch" for item in payload["comparison"]["stepDiffs"]))
         self.assertEqual(payload["runs"][1]["insights"]["github"]["latestFailure"]["stepId"], "draft_pr")
         self.assertEqual(
@@ -1858,6 +1936,146 @@ class WebHermesInsightTests(unittest.TestCase):
         self.assertEqual(roles["triage"], "supervisor")
         self.assertEqual(insights["hermes"]["sessionCount"], 2)
         self.assertTrue(insights["hermes"]["used"])
+
+
+class WebUsageInsightTests(unittest.TestCase):
+    def test_openclaw_usage_is_aggregated_in_run_insights(self) -> None:
+        summary = {
+            "results": [
+                {
+                    "work_item_id": "triage",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 100,
+                            "output": 40,
+                            "cacheRead": 1000,
+                            "total": 140,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 10,
+                            "output": 4,
+                            "cacheRead": 100,
+                            "cacheWrite": 2,
+                            "total": 14,
+                        },
+                    },
+                },
+                {
+                    "work_item_id": "review",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {
+                            "input": 200,
+                            "output": 60,
+                            "cacheRead": 2000,
+                            "cacheWrite": 20,
+                            "total": 260,
+                        },
+                        "openclaw_last_call_usage": {
+                            "input": 20,
+                            "output": 6,
+                            "cacheRead": 200,
+                            "total": 26,
+                        },
+                    },
+                },
+                {
+                    "work_item_id": "implement",
+                    "status": "succeeded",
+                    "artifacts": {},
+                },
+            ],
+            "plan": [],
+        }
+
+        insights = _summarize_run_insights(
+            summary,
+            {},
+            None,
+            default_github_repo="",
+            github_base_branch="main",
+        )
+
+        usage = insights["usage"]
+        self.assertEqual(usage["resultCount"], 3)
+        self.assertEqual(usage["openclawUsageCount"], 2)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 2)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 300,
+                "output": 100,
+                "cacheRead": 3000,
+                "cacheWrite": 20,
+                "total": 400,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 30,
+                "output": 10,
+                "cacheRead": 300,
+                "cacheWrite": 2,
+                "total": 40,
+            },
+        )
+
+    def test_openclaw_usage_ignores_malformed_payloads(self) -> None:
+        summary = {
+            "results": [
+                {
+                    "work_item_id": "triage",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {"input": "100", "output": 10, "total": 20},
+                        "openclaw_last_call_usage": "bad",
+                    },
+                },
+                {
+                    "work_item_id": "review",
+                    "status": "succeeded",
+                    "artifacts": {
+                        "openclaw_usage": {"input": True, "cacheRead": 5, "total": 7},
+                    },
+                },
+            ],
+            "plan": [],
+        }
+
+        insights = _summarize_run_insights(
+            summary,
+            {},
+            None,
+            default_github_repo="",
+            github_base_branch="main",
+        )
+
+        usage = insights["usage"]
+        self.assertEqual(usage["resultCount"], 2)
+        self.assertEqual(usage["openclawUsageCount"], 2)
+        self.assertEqual(usage["openclawLastCallUsageCount"], 0)
+        self.assertEqual(
+            usage["openclawUsage"],
+            {
+                "input": 0,
+                "output": 10,
+                "cacheRead": 5,
+                "cacheWrite": 0,
+                "total": 27,
+            },
+        )
+        self.assertEqual(
+            usage["openclawLastCallUsage"],
+            {
+                "input": 0,
+                "output": 0,
+                "cacheRead": 0,
+                "cacheWrite": 0,
+                "total": 0,
+            },
+        )
 
 
 class WebGitHubInsightTests(unittest.TestCase):

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -1450,6 +1450,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
     async def test_run_task_captures_progress_and_result(self) -> None:
         run_artifacts = os.path.join(self.repo_path, ".openclaw", "runs", "run-web-test")
         os.makedirs(run_artifacts, exist_ok=True)
+        captured: dict[str, str] = {}
         with open(os.path.join(run_artifacts, "summary.json"), "w", encoding="utf-8") as handle:
             json.dump(
                 {
@@ -1506,6 +1507,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
                 return []
 
             async def run(self, user_request, repo_path, selected_steps=None, progress_callback=None):
+                captured["workflow_run_ref"] = getattr(self, "workflow_run_ref", "")
                 if progress_callback is not None:
                     progress_callback("preflight:start")
                     progress_callback("step:done implement -> succeeded")
@@ -1521,6 +1523,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
                     "pipeline": "demo_pipeline",
                     "request": "Add a Web UI",
                     "steps": ["implement"],
+                    "workflowRunRef": "25504962543",
                     "live": False,
                 },
             )
@@ -1543,6 +1546,7 @@ class WebRunTaskTests(unittest.IsolatedAsyncioTestCase):
             messages = [item["message"] for item in task_payload["progress"]]
             self.assertIn("preflight:start", messages)
             self.assertIn("step:done implement -> succeeded", messages)
+            self.assertEqual(captured["workflow_run_ref"], "25504962543")
             self.assertEqual(task_payload["result"]["mode"], "run")
             self.assertEqual(task_payload["result"]["runResult"]["run_id"], "run-web-test")
             self.assertEqual(task_payload["result"]["history"]["runId"], "run-web-test")

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -159,6 +159,23 @@ class WebUiStaticTests(unittest.TestCase):
         )
         self.assertIn("comparison.usageDelta", source)
 
+    def test_preflight_recovery_hint_is_shared_across_copy_surfaces(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("function currentPreflightRecoveryHint()", source)
+        self.assertIn("function formatPreflightRecoveryLine(preflightRecovery)", source)
+        self.assertIn("const preflightRecovery = currentPreflightRecoveryHint();", source)
+        self.assertIn('<div><dt>Preflight recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>', source)
+        self.assertIn("const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());", source)
+        self.assertEqual(source.count("lines.push(preflightRecoveryLine);"), 2)
+        self.assertEqual(source.count("lines.push(`- ${preflightRecoveryLine}`);"), 1)
+        self.assertEqual(
+            source.count("const preflightRecoveryLine = formatPreflightRecoveryLine(currentPreflightRecoveryHint());"),
+            3,
+        )
+
     def test_run_detail_surfaces_latest_github_failure(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -12,6 +12,15 @@ class WebUiStaticTests(unittest.TestCase):
         self.assertIn('return `<span class=\"status-chip ${tone}\">${escapeHtml(normalized)}</span>`;', source)
         self.assertNotIn('class=\"status-chip ${normalized}\"', source)
 
+    def test_launch_pad_exposes_workflow_run_ref_input(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "index.html").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('id="workflow-run-ref"', source)
+        self.assertIn('name="workflowRunRef"', source)
+        self.assertIn("Resume an existing GitHub Actions workflow run", source)
+
     def test_channel_health_status_uses_helper(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"
@@ -24,6 +33,19 @@ class WebUiStaticTests(unittest.TestCase):
             '${makeStatusChip(channels.every((item) => item.probeOk) ? "passed" : "warning")}',
             source,
         )
+
+    def test_task_payload_includes_workflow_run_ref_and_ready_state_checks_it(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("function currentWorkflowRunRef()", source)
+        self.assertIn("function pipelineRequiresWorkflowRunRef()", source)
+        self.assertIn("function workflowRunRefReady()", source)
+        self.assertIn("workflowRunRef: currentWorkflowRunRef(),", source)
+        self.assertIn("const workflowRunRefIsReady = workflowRunRefReady();", source)
+        self.assertIn("elements.workflowRunRef.addEventListener(\"input\"", source)
+        self.assertIn("workflowRunRefReady()", source)
 
     def test_preflight_snapshot_status_is_shared_between_panels(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -131,9 +131,12 @@ class WebUiStaticTests(unittest.TestCase):
 
         self.assertIn("function formatOpenClawUsageSummary(usage)", source)
         self.assertIn("function formatOpenClawUsageDelta(usageDelta)", source)
+        self.assertIn("function formatOpenClawUsageTrend(runs)", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(insights?.usage || null);", source)
         self.assertIn("const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);", source)
+        self.assertIn("const usageTrend = formatOpenClawUsageTrend(runs);", source)
+        self.assertIn("OpenClaw usage trend", source)
         self.assertIn("OpenClaw usage", source)
         self.assertIn("OpenClaw usage delta", source)
         self.assertIn(

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -132,13 +132,20 @@ class WebUiStaticTests(unittest.TestCase):
         self.assertIn("function formatOpenClawUsageSummary(usage)", source)
         self.assertIn("function formatOpenClawUsageDelta(usageDelta)", source)
         self.assertIn("function formatOpenClawUsageTrend(runs)", source)
+        self.assertIn("function currentOpenClawUsage()", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);", source)
         self.assertIn("const usageLine = formatOpenClawUsageSummary(insights?.usage || null);", source)
         self.assertIn("const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);", source)
         self.assertIn("const usageTrend = formatOpenClawUsageTrend(runs);", source)
+        self.assertIn("const usageLine = formatOpenClawUsageSummary(currentOpenClawUsage());", source)
+        self.assertIn("lines.push(usageLine);", source)
+        self.assertIn("lines.push(`- ${usageLine}`);", source)
         self.assertIn("OpenClaw usage trend", source)
         self.assertIn("OpenClaw usage", source)
         self.assertIn("OpenClaw usage delta", source)
+        self.assertIn("generateRunSummaryText()", source)
+        self.assertIn("generateIssueUpdateText()", source)
+        self.assertIn("generatePrNoteText()", source)
         self.assertIn(
             "chunks.push(renderRunResults(payload.runResult, payload.history?.insights || payload.insights || null));",
             source,

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -124,12 +124,34 @@ class WebUiStaticTests(unittest.TestCase):
         self.assertIn("formatGitHubFailureLine(run.insights?.github?.latestFailure || null)", source)
         self.assertIn("Recovery: ${failureRecovery}", source)
 
+    def test_openclaw_usage_is_rendered_from_run_insights(self) -> None:
+        source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn("function formatOpenClawUsageSummary(usage)", source)
+        self.assertIn("function formatOpenClawUsageDelta(usageDelta)", source)
+        self.assertIn("const usageLine = formatOpenClawUsageSummary(run.insights?.usage || null);", source)
+        self.assertIn("const usageLine = formatOpenClawUsageSummary(insights?.usage || null);", source)
+        self.assertIn("const usageDeltaLine = formatOpenClawUsageDelta(comparison.usageDelta || null);", source)
+        self.assertIn("OpenClaw usage", source)
+        self.assertIn("OpenClaw usage delta", source)
+        self.assertIn(
+            "chunks.push(renderRunResults(payload.runResult, payload.history?.insights || payload.insights || null));",
+            source,
+        )
+        self.assertIn(
+            "chunks.push(renderRunResults(payload.summary, payload.insights || null));",
+            source,
+        )
+        self.assertIn("comparison.usageDelta", source)
+
     def test_run_detail_surfaces_latest_github_failure(self) -> None:
         source = (Path(__file__).resolve().parents[1] / "openclaw_v2" / "webui" / "app.js").read_text(
             encoding="utf-8"
         )
 
-        self.assertIn("function renderRunResults(runResult)", source)
+        self.assertIn("function renderRunResults(runResult, insights = null)", source)
         self.assertIn("const workflow = currentGitHubWorkflow();", source)
         self.assertIn("const failure = currentGitHubFailure();", source)
         self.assertIn("const failureLine = formatGitHubFailureLine(failure);", source)

--- a/tests/test_webui_static.py
+++ b/tests/test_webui_static.py
@@ -54,11 +54,14 @@ class WebUiStaticTests(unittest.TestCase):
 
         self.assertIn("function latestPreflightSource()", source)
         self.assertIn("function preflightSnapshotStatus(checks)", source)
+        self.assertIn("function formatPreflightRecoveryHint(checks)", source)
         self.assertIn("const preflight = preflightSnapshotStatus(preflightChecks);", source)
+        self.assertIn("const preflightRecovery = formatPreflightRecoveryHint(preflightChecks);", source)
         self.assertIn("const preflight = preflightSnapshotStatus(latestPreflightChecks());", source)
         self.assertIn("const preflightSource = latestPreflightSource();", source)
         self.assertIn("<div><dt>Source</dt><dd>${escapeHtml(preflightSource)}</dd></div>", source)
         self.assertIn('${makeStatusChip(preflight.status)}', source)
+        self.assertIn('<div><dt>Recovery</dt><dd>${escapeHtml(preflightRecovery)}</dd></div>', source)
         self.assertNotIn(
             'No preflight snapshot loaded yet.',
             source.split("function preflightSnapshotStatus(checks)")[0],


### PR DESCRIPTION
OpenClaw generated this draft PR request.

## Task
Prepare GitHub draft PR summary

## Prompt
请把本地实现结果整理为 Draft PR 描述，便于后续人工审核和合并。

用户请求：
在 README.md 的 mission_control_default 说明里补一条，说明在 Claude CLI 暂时不可用时，可以用 OPENCLAW_ASSIGN_TRIAGE_LOCAL=openclaw_router 和 OPENCLAW_ASSIGN_REVIEW_LOCAL=openclaw_router 临时把 triage / review 切到 OpenClaw，以便默认尾链继续跑；这次只新增这一条，不改别的内容。

Dependency summaries:
- publish_branch: CLI task Publish implementation branch to origin finished successfully.
branch 'openclaw-run-20260512t102057z-4098c0-implement' set up to track 'origin/openclaw-run-20260512t102057z-4098c0-implement'.
- review: OpenClaw task Review implementation before publish finished successfully.
- sync_issue: GitHub workflow task Sync planning issue to GitHub finished successfully after 2 attempts. Retried without labels: openclaw, planning.
https://github.com/crused-fall/Openclaw-AIagent-control/issues/32
- update_issue: GitHub workflow task Update GitHub issue with implementation status finished successfully.
https://github.com/crused-fall/Openclaw-AIagent-control/issues/32#issuecomment-4429554737

建议使用的实现分支：
openclaw-run-20260512t102057z-4098c0-implement
