### PR TITLE
fix: normalize Windows runtime path handling

### DIFF
--- a/PROJECT_MEMORY.md
+++ b/PROJECT_MEMORY.md
@@ -1,5 +1,12 @@
 # OpenClaw Working Memory
 
+## 2026-05-13 Working Note
+
+- Current Windows queue slice: keep POSIX-style runtime paths stable across config resolution, run context creation, worktree allocation, and executor handoff prompts.
+- Touched files in this slice: `openclaw_v2/paths.py`, `openclaw_v2/config.py`, `openclaw_v2/orchestrator.py`, `openclaw_v2/worktree.py`, `openclaw_v2/executors/openclaw.py`, `openclaw_v2/executors/hermes.py`, plus focused regression tests.
+- Next likely slice: investigate the separate config-loader dependency gap (`PyYAML`/Ruby fallback) now that Windows path regressions are covered.
+
+
 更新时间：2026-05-07
 
 ## 主目标

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,5 +1,11 @@
 # OpenClaw Project Status
 
+## 2026-05-13 Update
+
+- Normalized POSIX-style runtime paths on Windows for `resolve_runtime_path`, orchestration run roots, worktree paths, and agent handoff `AGENTS.md` references.
+- Added regression coverage for Windows path handling in `tests/test_config_loader.py`, `tests/test_orchestrator.py`, `tests/test_openclaw_executor.py`, `tests/test_hermes_executor.py`, and `tests/test_worktree.py`.
+
+
 更新时间：2026-05-07
 
 ## 当前记录入口

--- a/openclaw_v2/config.py
+++ b/openclaw_v2/config.py
@@ -15,6 +15,7 @@ except ModuleNotFoundError:
     yaml = None
 
 from .models import AgentType, CheckStatus, ExecutionMode, PreflightCheck
+from .paths import is_absolute_runtime_path, join_runtime_path
 
 
 @dataclass
@@ -914,6 +915,6 @@ def load_app_config(path: str) -> AppConfig:
 
 
 def resolve_runtime_path(base_path: str, configured_path: str) -> str:
-    if os.path.isabs(configured_path):
-        return configured_path
-    return os.path.join(base_path, configured_path)
+    if is_absolute_runtime_path(configured_path):
+        return configured_path.replace("\\", "/") if configured_path.startswith("/") else configured_path
+    return join_runtime_path(base_path, configured_path)

--- a/openclaw_v2/executors/hermes.py
+++ b/openclaw_v2/executors/hermes.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 import asyncio
-import os
 import re
 
 from ..config import ProfileConfig
 from ..models import AgentResult, ExecutionContext, TaskStatus, WorkItem, parse_control_output
+from ..paths import join_runtime_path
 from .base import Executor
 
 
@@ -45,7 +45,7 @@ class HermesExecutor(Executor):
         work_item: WorkItem,
     ) -> str:
         target_path = work_item.workspace_path or context.repo_path
-        agents_path = os.path.join(target_path, "AGENTS.md")
+        agents_path = join_runtime_path(target_path, "AGENTS.md")
         lines = [
             "Hermes repository handoff:",
             f"- Primary repository path: {target_path}",

--- a/openclaw_v2/executors/openclaw.py
+++ b/openclaw_v2/executors/openclaw.py
@@ -2,11 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from typing import Any
 
 from ..config import ProfileConfig
 from ..models import AgentResult, ExecutionContext, TaskStatus, WorkItem, parse_control_output
+from ..paths import join_runtime_path
 from .base import Executor
 
 
@@ -38,7 +38,7 @@ class OpenClawExecutor(Executor):
         work_item: WorkItem,
     ) -> str:
         target_path = work_item.workspace_path or context.repo_path
-        agents_path = os.path.join(target_path, "AGENTS.md")
+        agents_path = join_runtime_path(target_path, "AGENTS.md")
         lines = [
             "OpenClaw repository handoff:",
             f"- Primary repository path: {target_path}",

--- a/openclaw_v2/orchestrator.py
+++ b/openclaw_v2/orchestrator.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from .artifacts import ArtifactStore
 from .config import AppConfig, resolve_runtime_path
+from .paths import join_runtime_path
 from .executors import CLIExecutor, GitHubWorkflowExecutor, HermesExecutor, OpenClawExecutor
 from .models import AgentResult, CheckStatus, ExecutionContext, ExecutionMode, RunResult, TaskStatus, WorkItem
 from .planner import PipelinePlanner
@@ -441,8 +442,8 @@ class HybridOrchestrator:
             user_request=user_request,
             repo_path=repo_path,
             dry_run=self.config.runtime.dry_run,
-            artifacts_dir=os.path.join(artifacts_root, run_id),
-            worktrees_dir=os.path.join(worktrees_root, run_id),
+            artifacts_dir=join_runtime_path(artifacts_root, run_id),
+            worktrees_dir=join_runtime_path(worktrees_root, run_id),
         )
         self.artifact_store.initialize_run(context, plan)
         self._emit_progress(progress_callback, "preflight:start")

--- a/openclaw_v2/paths.py
+++ b/openclaw_v2/paths.py
@@ -1,0 +1,42 @@
+﻿from __future__ import annotations
+
+import ntpath
+import os
+import posixpath
+
+
+def _is_posix_absolute(path: str) -> bool:
+    return posixpath.isabs(path)
+
+
+def _looks_like_windows_path(path: str) -> bool:
+    drive, _ = ntpath.splitdrive(path)
+    return bool(drive) or path.startswith("\\") or path.startswith("//") or "\\" in path
+
+
+def normalize_runtime_path(path: str) -> str:
+    if _is_posix_absolute(path):
+        return path.replace("\\", "/")
+    if _looks_like_windows_path(path):
+        return path.replace("/", "\\")
+    return path
+
+
+def is_absolute_runtime_path(path: str) -> bool:
+    return _is_posix_absolute(path) or ntpath.isabs(path)
+
+
+def join_runtime_path(base_path: str, *parts: str) -> str:
+    normalized_base = normalize_runtime_path(base_path)
+    if not parts:
+        return normalized_base
+
+    if _is_posix_absolute(normalized_base):
+        normalized_parts = [part.replace("\\", "/") for part in parts]
+        return posixpath.join(normalized_base, *normalized_parts)
+
+    if _looks_like_windows_path(normalized_base):
+        normalized_parts = [part.replace("/", "\\") for part in parts]
+        return ntpath.join(normalized_base, *normalized_parts)
+
+    return os.path.join(normalized_base, *parts)

--- a/openclaw_v2/worktree.py
+++ b/openclaw_v2/worktree.py
@@ -5,6 +5,7 @@ import os
 import re
 
 from .models import ExecutionContext, ExecutionMode, WorkItem
+from .paths import join_runtime_path
 
 
 class WorktreeManager:
@@ -44,7 +45,7 @@ class WorktreeManager:
             work_item.metadata["workspace_prepared"] = True
             return
 
-        workspace_path = os.path.join(context.worktrees_dir, work_item.id)
+        workspace_path = join_runtime_path(context.worktrees_dir, work_item.id)
         branch_name = self._branch_name(context.run_id, work_item.id)
 
         work_item.workspace_path = workspace_path

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -6,11 +6,17 @@ import subprocess
 from unittest import mock
 from types import SimpleNamespace
 
-from openclaw_v2.config import _load_yaml, load_app_config
+from openclaw_v2.config import _load_yaml, load_app_config, resolve_runtime_path
 from openclaw_v2.models import AgentType, ExecutionMode
 
 
 class ConfigLoaderTests(unittest.TestCase):
+    def test_resolve_runtime_path_preserves_posix_absolute_configured_path(self) -> None:
+        self.assertEqual(
+            resolve_runtime_path(r"C:\\repo", "/tmp/openclaw-worktrees"),
+            "/tmp/openclaw-worktrees",
+        )
+
     def test_load_yaml_ruby_fallback_uses_safe_load(self) -> None:
         with tempfile.NamedTemporaryFile("w+", suffix=".yaml", encoding="utf-8") as handle:
             handle.write("runtime:\n  pipeline: demo\n")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -2,7 +2,7 @@ import os
 import unittest
 from unittest import mock
 
-from openclaw_v2.config import load_app_config
+from openclaw_v2.config import AppConfig, GitHubConfig, RuntimeConfig, load_app_config
 from openclaw_v2.models import AgentResult, AgentType, ExecutionContext, ExecutionMode, TaskStatus, WorkItem
 from openclaw_v2.orchestrator import HybridOrchestrator
 
@@ -338,6 +338,61 @@ class OrchestratorDependencyTests(unittest.TestCase):
 
 
 class OrchestratorExecutionTests(unittest.IsolatedAsyncioTestCase):
+    async def test_run_preserves_posix_runtime_roots_in_context(self) -> None:
+        config = AppConfig(
+            runtime=RuntimeConfig(
+                pipeline="mission_control_default",
+                dry_run=True,
+                artifacts_dir="/tmp/artifacts",
+                worktrees_dir="/tmp/worktrees",
+            ),
+            github=GitHubConfig(),
+            profiles={},
+            managed_agents={},
+            assignments={},
+            pipelines={},
+        )
+        orchestrator = HybridOrchestrator(config)
+        preflight_report = mock.Mock(ok=True, checks=[])
+        captured_context = None
+
+        def capture_initialize_run(context, plan) -> None:
+            nonlocal captured_context
+            captured_context = context
+
+        with mock.patch.object(orchestrator, "build_plan", return_value=[]), mock.patch.object(
+            HybridOrchestrator,
+            "_make_run_id",
+            return_value="run-fixed",
+        ), mock.patch.object(
+            orchestrator.preflight_runner,
+            "run",
+            new=mock.AsyncMock(return_value=preflight_report),
+        ), mock.patch.object(
+            orchestrator.worktree_manager,
+            "cleanup",
+            new=mock.AsyncMock(),
+        ), mock.patch.object(
+            orchestrator.artifact_store,
+            "initialize_run",
+            side_effect=capture_initialize_run,
+        ), mock.patch.object(
+            orchestrator.artifact_store,
+            "write_preflight_report",
+        ), mock.patch.object(
+            orchestrator.artifact_store,
+            "write_run_summary",
+        ), mock.patch.object(
+            orchestrator.artifact_store,
+            "write_workspace_manifest",
+        ):
+            result = await orchestrator.run("test", r"C:\\repo")
+
+        self.assertTrue(result.success)
+        self.assertIsNotNone(captured_context)
+        self.assertEqual(captured_context.artifacts_dir, "/tmp/artifacts/run-fixed")
+        self.assertEqual(captured_context.worktrees_dir, "/tmp/worktrees/run-fixed")
+
     async def test_execute_ready_items_blocks_planning_errors_without_preparation(self) -> None:
         orchestrator = HybridOrchestrator(load_app_config("config_v2.yaml"))
         context = ExecutionContext(


### PR DESCRIPTION
## What
- normalize POSIX-style runtime paths on Windows during config resolution and run context creation
- preserve `AGENTS.md` handoff paths and worktree paths when the configured roots use forward slashes
- add focused regression tests for config resolution and orchestrator/worktree/executor path handling

## Verification
- `python -m unittest tests.test_config_loader.ConfigLoaderTests.test_resolve_runtime_path_preserves_posix_absolute_configured_path tests.test_openclaw_executor.OpenClawExecutorTests.test_prepare_prompt_includes_repo_handoff tests.test_hermes_executor.HermesExecutorTests.test_prepare_prompt_includes_repo_handoff tests.test_worktree.WorktreeManagerReuseTests.test_prepare_openclaw_export_step_uses_worktree_in_dry_run tests.test_orchestrator.OrchestratorExecutionTests.test_run_preserves_posix_runtime_roots_in_context -v`
- `python -m py_compile openclaw_v2/paths.py openclaw_v2/config.py openclaw_v2/orchestrator.py openclaw_v2/worktree.py openclaw_v2/executors/openclaw.py openclaw_v2/executors/hermes.py tests/test_config_loader.py tests/test_orchestrator.py`

## Note
- there is still a separate Windows config-loader dependency issue (`PyYAML`/Ruby fallback) that remains for a follow-up slice.